### PR TITLE
Fix spelling mistake for 'Cannon Lake'

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -83,7 +83,7 @@ typedef enum {
   INTEL_ATOM_GMT,  // GOLDMONT
   INTEL_KBL,       // KABY LAKE
   INTEL_CFL,       // COFFEE LAKE
-  INTEL_CNL,       // CANON LAKE
+  INTEL_CNL,       // CANNON LAKE
   AMD_HAMMER,      // K8
   AMD_K10,         // K10
   AMD_BOBCAT,      // K14


### PR DESCRIPTION
See:
https://www.intel.com/content/www/us/en/design/products-and-solutions/processors-and-chipsets/platform-codenames.html
https://en.wikipedia.org/wiki/Cannon_Lake_(microarchitecture)