### PR TITLE
without cpu_features_macros.h in the install tree, the library cannot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(_HDRS
   include/cpuinfo_mips.h
   include/cpuinfo_ppc.h
   include/cpuinfo_x86.h
+  include/cpu_features_macros.h
 )
 
 add_library(cpu_features


### PR DESCRIPTION
be used after `make install`