### PR TITLE
glibc < 2.16 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ add_library(cpu_features
   src/string_view.c
 )
 
+include(CheckIncludeFiles)
+check_include_files(sys/auxv.h HAVE_SYS_AUXV_H)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/config.h)
+
 target_include_directories(cpu_features
   PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,6 @@
+#ifndef _CPU_FEATURES_CONFIG_H
+#define _CPU_FEATURES_CONFIG_H
+
+#cmakedefine HAVE_SYS_AUXV_H @HAVE_SYS_AUXV_H@
+
+#endif /* _CPU_FEATURES_CONFIG_H */

--- a/src/hwcaps.c
+++ b/src/hwcaps.c
@@ -19,6 +19,7 @@
 #include "internal/filesystem.h"
 #include "internal/hwcaps.h"
 #include "internal/string_view.h"
+#include "config.h"
 
 #if defined(NDEBUG)
 #define D(...)
@@ -51,10 +52,20 @@
 // On Linux we simply use getauxval.
 #if defined(HWCAPS_REGULAR_LINUX)
 #include <dlfcn.h>
+#if defined(HAVE_SYS_AUXV_H)
 #include <sys/auxv.h>
 static unsigned long GetElfHwcapFromGetauxval(uint32_t hwcap_type) {
   return getauxval(hwcap_type);
 }
+#else // Without sys/auxv.h return 0 to fallback to GetElfHwcapFromProcSelfAuxv
+#include <elf.h>
+#ifndef AT_HWCAP2
+#define AT_HWCAP2 26
+#endif
+static unsigned long GetElfHwcapFromGetauxval(uint32_t hwcap_type) {
+  return 0;
+}
+#endif  // defined(HAVE_SYS_AUXV_H)
 #endif  // defined(HWCAPS_REGULAR_LINUX)
 
 // On Android we probe the system's C library for a 'getauxval' function and


### PR DESCRIPTION
Older glibc does not have getauxval.  Writing getauxval is pretty simple but simpler again is falling back to GetElfHwcapFromProcSelfAuxv