### PR TITLE
Fix a few build warnings

### DIFF
--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -64,7 +64,7 @@ Leaf CpuIdEx(uint32_t leaf_id, int ecx) {
   return leaf;
 }
 
-uint32_t GetXCR0Eax(void) { return _xgetbv(0); }
+uint32_t GetXCR0Eax(void) { return (uint32_t)_xgetbv(0); }
 
 #else
 #error "Unsupported compiler, x86 cpuid requires either GCC, Clang or MSVC."

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -16,6 +16,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -24,14 +25,16 @@
 #elif defined(_MSC_VER)
 #include <io.h>
 int CpuFeatures_OpenFile(const char* filename) {
-  return _open(filename, _O_RDONLY);
+  int fd = -1;
+  _sopen_s(&fd, filename, _O_RDONLY, _SH_DENYWR, _S_IREAD);
+  return fd;
 }
 
 void CpuFeatures_CloseFile(int file_descriptor) { _close(file_descriptor); }
 
 int CpuFeatures_ReadFile(int file_descriptor, void* buffer,
                          size_t buffer_size) {
-  return _read(file_descriptor, buffer, buffer_size);
+  return _read(file_descriptor, buffer, (unsigned int)buffer_size);
 }
 
 #else

--- a/src/string_view.c
+++ b/src/string_view.c
@@ -22,7 +22,7 @@ int CpuFeatures_StringView_IndexOfChar(const StringView view, char c) {
   if (view.ptr && view.size) {
     const char* const found = (const char*)memchr(view.ptr, c, view.size);
     if (found) {
-      return found - view.ptr;
+      return (int)(found - view.ptr);
     }
   }
   return -1;
@@ -38,7 +38,7 @@ int CpuFeatures_StringView_IndexOf(const StringView view,
       if (found_index < 0) break;
       remainder = CpuFeatures_StringView_PopFront(remainder, found_index);
       if (CpuFeatures_StringView_StartsWith(remainder, sub_view)) {
-        return remainder.ptr - view.ptr;
+        return (int)(remainder.ptr - view.ptr);
       }
       remainder = CpuFeatures_StringView_PopFront(remainder, 1);
     }

--- a/src/utils/list_cpu_features.c
+++ b/src/utils/list_cpu_features.c
@@ -136,7 +136,7 @@ static int cmp(const void* p1, const void* p2) {
         ++count;                                                           \
       }                                                                    \
     }                                                                      \
-    qsort(ptrs, count, sizeof(char*), cmp);                                \
+    qsort((void*)ptrs, count, sizeof(char*), cmp);                         \
     p.StartField("flags");                                                 \
     p.ArrayStart();                                                        \
     for (i = 0; i < count; ++i) {                                          \

--- a/test/bit_utils_test.cc
+++ b/test/bit_utils_test.cc
@@ -22,18 +22,18 @@ namespace {
 TEST(UtilsTest, IsBitSet) {
   for (size_t bit_set = 0; bit_set < 32; ++bit_set) {
     const uint32_t value = 1UL << bit_set;
-    for (size_t i = 0; i < 32; ++i) {
+    for (uint32_t i = 0; i < 32; ++i) {
       EXPECT_EQ(IsBitSet(value, i), i == bit_set);
     }
   }
 
   // testing 0, all bits should be 0.
-  for (size_t i = 0; i < 32; ++i) {
+  for (uint32_t i = 0; i < 32; ++i) {
     EXPECT_FALSE(IsBitSet(0, i));
   }
 
   // testing ~0, all bits should be 1.
-  for (size_t i = 0; i < 32; ++i) {
+  for (uint32_t i = 0; i < 32; ++i) {
     EXPECT_TRUE(IsBitSet(-1, i));
   }
 }

--- a/test/filesystem_for_testing.cc
+++ b/test/filesystem_for_testing.cc
@@ -45,7 +45,7 @@ int FakeFile::Read(int fd, void* buf, size_t count) {
   memcpy(buf, content_.data() + head_index_, read);
   head_index_ += read;
   assert(read < INT_MAX);
-  return read;
+  return (int)read;
 }
 
 void FakeFilesystem::Reset() { files_.clear(); }

--- a/test/filesystem_for_testing.h
+++ b/test/filesystem_for_testing.h
@@ -50,7 +50,7 @@ class FakeFilesystem {
   FakeFile* FindFileOrNull(const std::string& filename) const;
 
  private:
-  size_t next_file_descriptor_ = 0;
+  int next_file_descriptor_ = 0;
   std::unordered_map<std::string, std::unique_ptr<FakeFile>> files_;
 };
 


### PR DESCRIPTION
Visual C++ reported a number of warnings:

..\src\filesystem.c(27): warning C4996: '_open': This function or variable may be unsafe. Consider using _sopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
..\src\filesystem.c(34): warning C4267: 'function': conversion from 'size_t' to 'unsigned int', possible loss of data
..\src\string_view.c(25): warning C4244: 'return': conversion from '__int64' to 'int', possible loss of data
..\src\string_view.c(41): warning C4244: 'return': conversion from '__int64' to 'int', possible loss of data
..\src\utils\list_cpu_features.c(151): warning C4090: 'function': different 'const' qualifiers
..\src\cpuinfo_x86.c(67): warning C4244: 'return': conversion from 'unsigned __int64' to 'uint32_t', possible loss of data
..\test\filesystem_for_testing.cc(48): warning C4267: 'return': conversion from 'size_t' to 'int', possible loss of data
..\test\filesystem_for_testing.cc(57): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
..\test\bit_utils_test.cc(26): warning C4267: 'argument': conversion from 'size_t' to 'uint32_t', possible loss of data
..\test\bit_utils_test.cc(32): warning C4267: 'argument': conversion from 'size_t' to 'uint32_t', possible loss of data
..\test\bit_utils_test.cc(37): warning C4267: 'argument': conversion from 'size_t' to 'uint32_t', possible loss of data

Most of them, with the exception of _open() -> _sopen_s() are about
questionable implicit casts. Fixing the types and adding explicit casts
to explicitly mark the intention (and silence the warnings in the process)