### PR TITLE
Support CherryTrail that doesn't indicate xmm os support

### DIFF
--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -96,12 +96,6 @@ static bool HasMask(uint32_t value, uint32_t mask) {
   return (value & mask) == mask;
 }
 
-// Checks that operating system saves and restores xmm registers during context
-// switches.
-static bool HasXmmOsXSave(uint32_t xcr0_eax) {
-  return HasMask(xcr0_eax, MASK_XMM);
-}
-
 // Checks that operating system saves and restores ymm registers during context
 // switches.
 static bool HasYmmOsXSave(uint32_t xcr0_eax) {
@@ -528,7 +522,6 @@ static void ParseCpuId(const uint32_t max_cpuid_leaf, X86Info* info) {
   const bool have_xsave = IsBitSet(leaf_1.ecx, 26);
   const bool have_osxsave = IsBitSet(leaf_1.ecx, 27);
   const uint32_t xcr0_eax = (have_xsave && have_osxsave) ? GetXCR0Eax() : 0;
-  const bool have_sse_os_support = HasXmmOsXSave(xcr0_eax);
   const bool have_avx_os_support = HasYmmOsXSave(xcr0_eax);
   const bool have_avx512_os_support = HasZmmOsXSave(xcr0_eax);
 
@@ -571,14 +564,12 @@ static void ParseCpuId(const uint32_t max_cpuid_leaf, X86Info* info) {
   features->vaes = IsBitSet(leaf_7.ecx, 9);
   features->vpclmulqdq = IsBitSet(leaf_7.ecx, 10);
 
-  if (have_sse_os_support) {
-    features->sse = IsBitSet(leaf_1.edx, 25);
-    features->sse2 = IsBitSet(leaf_1.edx, 26);
-    features->sse3 = IsBitSet(leaf_1.ecx, 0);
-    features->ssse3 = IsBitSet(leaf_1.ecx, 9);
-    features->sse4_1 = IsBitSet(leaf_1.ecx, 19);
-    features->sse4_2 = IsBitSet(leaf_1.ecx, 20);
-  }
+  features->sse = IsBitSet(leaf_1.edx, 25);
+  features->sse2 = IsBitSet(leaf_1.edx, 26);
+  features->sse3 = IsBitSet(leaf_1.ecx, 0);
+  features->ssse3 = IsBitSet(leaf_1.ecx, 9);
+  features->sse4_1 = IsBitSet(leaf_1.ecx, 19);
+  features->sse4_2 = IsBitSet(leaf_1.ecx, 20);
 
   if (have_avx_os_support) {
     features->fma3 = IsBitSet(leaf_1.ecx, 12);

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -277,5 +277,109 @@ TEST(CpuidX86Test, AMD_K15) {
 // TODO(user): test what happens when xmm/ymm/zmm os support are not
 // present.
 
+// example where xmm OS support is not present
+TEST(CpuidX86Test, CherryTrail_x5_Z8350) {
+  g_fake_cpu->SetOsBackupsExtendedRegisters(false);
+  g_fake_cpu->SetLeaves({
+      {{0x00000000, 0}, Leaf{0x0000000b, 0x756e6547, 0x6c65746e, 0x49656e69}}, // | ....GenuntelineI
+      {{0x00000001, 0}, Leaf{0x000406c4, 0x00100800, 0x43d8e3bf, 0xbfebfbff}}, // | ...........C....
+      {{0x00000002, 0}, Leaf{0x61b4a001, 0x0000ffc2, 0x00000000, 0x00000000}}, // | ...a............
+      {{0x00000003, 0}, Leaf{0x00000000, 0x00000000, 0x00000000, 0x00000000}}, // | ................
+      {{0x00000004, 0}, Leaf{0x1c000121, 0x0140003f, 0x0000003f, 0x00000001}}, // | !...?.@.?.......
+      {{0x00000004, 1}, Leaf{0x1c000122, 0x01c0003f, 0x0000003f, 0x00000001}}, // | "...?...?.......
+      {{0x00000004, 2}, Leaf{0x1c00c143, 0x03c0003f, 0x000003ff, 0x00000001}}, // | C...?...........
+      {{0x00000004, 3}, Leaf{0x00000000, 0x00000000, 0x00000000, 0x00000000}}, // | ................
+      {{0x00000005, 0}, Leaf{0x00000040, 0x00000040, 0x00000003, 0x33000020}}, // | @...@....... ..3
+      {{0x00000006, 0}, Leaf{0x00000007, 0x00000002, 0x00000009, 0x00000000}}, // | ................
+      {{0x00000007, 0}, Leaf{0x00000000, 0x00002282, 0x00000000, 0x0c000400}}, // | ....."..........
+      {{0x00000008, 0}, Leaf{0x00000000, 0x00000000, 0x00000000, 0x00000000}}, // | ................
+      {{0x00000009, 0}, Leaf{0x00000000, 0x00000000, 0x00000000, 0x00000000}}, // | ................
+      {{0x0000000a, 0}, Leaf{0x07280203, 0x00000000, 0x00000000, 0x00000503}}, // | ..(.............
+      {{0x0000000b, 0}, Leaf{0x00000001, 0x00000001, 0x00000100, 0x00000000}}, // | ................
+      {{0x0000000b, 1}, Leaf{0x00000004, 0x00000004, 0x00000201, 0x00000000}}, // | ................
+      {{0x0000000b, 2}, Leaf{0x00000000, 0x00000000, 0x00000002, 0x00000000}}, // | ................
+      {{0x40000000, 0}, Leaf{0x00000001, 0x00000001, 0x00000100, 0x00000000}}, // | ................
+      {{0x80000000, 0}, Leaf{0x80000008, 0x00000000, 0x00000000, 0x00000000}}, // | ................
+      {{0x80000001, 0}, Leaf{0x00000000, 0x00000000, 0x00000101, 0x28100800}}, // | ...............(
+      {{0x80000002, 0}, Leaf{0x20202020, 0x6e492020, 0x286c6574, 0x41202952}}, // |       Intel(R) A
+      {{0x80000003, 0}, Leaf{0x286d6f74, 0x20294d54, 0x5a2d3578, 0x30353338}}, // | tom(TM) x5-Z8350
+      {{0x80000004, 0}, Leaf{0x50432020, 0x20402055, 0x34342e31, 0x007a4847}}, // |   CPU @ 1.44GHz.
+      {{0x80000005, 0}, Leaf{0x00000000, 0x00000000, 0x00000000, 0x00000000}}, // | ................
+      {{0x80000006, 0}, Leaf{0x00000000, 0x00000000, 0x04008040, 0x00000000}}, // | ........@.......
+      {{0x80000007, 0}, Leaf{0x00000000, 0x00000000, 0x00000000, 0x00000100}}, // | ................
+      {{0x80000008, 0}, Leaf{0x00003024, 0x00000000, 0x00000000, 0x00000000}}, // | $0..............
+      
+  });
+  const auto info = GetX86Info();
+  EXPECT_STREQ(info.vendor, "GenuineIntel");
+
+  char brand_string[49];
+  FillX86BrandString(brand_string);
+  EXPECT_STREQ(brand_string, "      Intel(R) Atom(TM) x5-Z8350  CPU @ 1.44GHz");
+
+  EXPECT_EQ(info.family, 0x06);
+  EXPECT_EQ(info.model, 0x4C);
+  EXPECT_EQ(info.stepping, 0x04);
+
+  const auto features = info.features;
+  EXPECT_TRUE(features.fpu);
+  EXPECT_TRUE(features.tsc);
+  EXPECT_TRUE(features.cx8);
+  EXPECT_TRUE(features.clfsh);
+  EXPECT_TRUE(features.mmx);
+  EXPECT_TRUE(features.aes);
+  EXPECT_TRUE(features.erms);
+  EXPECT_FALSE(features.f16c);
+  EXPECT_FALSE(features.fma3);
+  EXPECT_FALSE(features.vaes);
+  EXPECT_FALSE(features.vpclmulqdq);
+  EXPECT_FALSE(features.bmi1);
+  EXPECT_FALSE(features.hle);
+  EXPECT_FALSE(features.bmi2);
+  EXPECT_FALSE(features.rtm);
+  EXPECT_FALSE(features.rdseed);
+  EXPECT_FALSE(features.clflushopt);
+  EXPECT_FALSE(features.clwb);
+
+  EXPECT_TRUE(features.sse);
+  EXPECT_TRUE(features.sse2);
+  EXPECT_TRUE(features.sse3);
+  EXPECT_TRUE(features.ssse3);
+  EXPECT_TRUE(features.sse4_1);
+  EXPECT_TRUE(features.sse4_2);
+
+  EXPECT_FALSE(features.avx);
+  EXPECT_FALSE(features.avx2);
+
+  EXPECT_FALSE(features.avx512f);
+  EXPECT_FALSE(features.avx512cd);
+  EXPECT_FALSE(features.avx512er);
+  EXPECT_FALSE(features.avx512pf);
+  EXPECT_FALSE(features.avx512bw);
+  EXPECT_FALSE(features.avx512dq);
+  EXPECT_FALSE(features.avx512vl);
+  EXPECT_FALSE(features.avx512ifma);
+  EXPECT_FALSE(features.avx512vbmi);
+  EXPECT_FALSE(features.avx512vbmi2);
+  EXPECT_FALSE(features.avx512vnni);
+  EXPECT_FALSE(features.avx512bitalg);
+  EXPECT_FALSE(features.avx512vpopcntdq);
+  EXPECT_FALSE(features.avx512_4vnniw);
+  EXPECT_FALSE(features.avx512_4vbmi2);
+
+  EXPECT_TRUE(features.pclmulqdq);
+  EXPECT_FALSE(features.smx);
+  EXPECT_FALSE(features.sgx);
+  EXPECT_TRUE(features.cx16);
+  EXPECT_FALSE(features.sha);
+  EXPECT_TRUE(features.popcnt);
+  EXPECT_TRUE(features.movbe);
+  EXPECT_TRUE(features.rdrnd);
+
+  EXPECT_FALSE(features.dca);
+  EXPECT_TRUE(features.ss);
+}
+
+
 }  // namespace
 }  // namespace cpu_features

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -321,6 +321,8 @@ TEST(CpuidX86Test, CherryTrail_x5_Z8350) {
   EXPECT_EQ(info.model, 0x4C);
   EXPECT_EQ(info.stepping, 0x04);
 
+  EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_ATOM_SMT);
+
   const auto features = info.features;
   EXPECT_TRUE(features.fpu);
   EXPECT_TRUE(features.tsc);


### PR DESCRIPTION
There was already a debate in https://github.com/google/cpu_features/issues/4 if cpus that do not set the XCR0 properly related to the xmm os support should be supported or not.
I stumpled across a CherryTail Atom that explicitly has this issue: XCR0 bit for xmm not set, but providing SSE* register set.

Now, on the one hand the debate above depicted "won't fix" as there won't be that many cpus with this issue. This is odd, because on the front page of https://github.com/google/cpu_features it is clearly depicted that a dev needs to take care about poor hardware implementations (example with SNB and AVX) in his/her own code. But in this case cpu_features tries to take control in case the bit in XCR0 for xmm os support is (not) set. I'd suggest to make the XCR0 xmm os support bit explicit to the dev so he/she can decide as well?
Hence, this patch removes so far the burden of not properly indicating SSE* on cpus that didn't set the XCR0 register properly, but still support SSE*.