### PR TITLE
Use a getter function to avoid manual work for future to-be-added cpu…

### DIFF
--- a/include/internal/unix_features_aggregator.h
+++ b/include/internal/unix_features_aggregator.h
@@ -33,11 +33,23 @@ CPU_FEATURES_START_CPP_NAMESPACE
     ((FeatureType*)features)->FeatureName = value;                  \
   }
 
+// Use the following macro to declare getter functions to be used in
+// CapabilityConfig.
+#define DECLARE_GETTER(FeatureType, FeatureName)                    \
+  static int get_##FeatureName(void* const features) {              \
+    return ((FeatureType*)features)->FeatureName;                   \
+  }
+
+#define DECLARE_SETTER_AND_GETTER(FeatureType, FeatureName)         \
+  DECLARE_SETTER(FeatureType, FeatureName)                          \
+  DECLARE_GETTER(FeatureType, FeatureName)
+
 // Describes the relationship between hardware caps and /proc/cpuinfo flags.
 typedef struct {
   const HardwareCapabilities hwcaps_mask;
   const char* const proc_cpuinfo_flag;
   void (*set_bit)(void* const, bool);  // setter for the corresponding bit.
+  int (*get_bit)(void* const); // getter for the corresponding bit.
 } CapabilityConfig;
 
 // For every config, looks into flags_line for the presence of the

--- a/src/cpuinfo_aarch64.c
+++ b/src/cpuinfo_aarch64.c
@@ -23,72 +23,72 @@
 #include <assert.h>
 #include <ctype.h>
 
-DECLARE_SETTER(Aarch64Features, fp)
-DECLARE_SETTER(Aarch64Features, asimd)
-DECLARE_SETTER(Aarch64Features, evtstrm)
-DECLARE_SETTER(Aarch64Features, aes)
-DECLARE_SETTER(Aarch64Features, pmull)
-DECLARE_SETTER(Aarch64Features, sha1)
-DECLARE_SETTER(Aarch64Features, sha2)
-DECLARE_SETTER(Aarch64Features, crc32)
-DECLARE_SETTER(Aarch64Features, atomics)
-DECLARE_SETTER(Aarch64Features, fphp)
-DECLARE_SETTER(Aarch64Features, asimdhp)
-DECLARE_SETTER(Aarch64Features, cpuid)
-DECLARE_SETTER(Aarch64Features, asimdrdm)
-DECLARE_SETTER(Aarch64Features, jscvt)
-DECLARE_SETTER(Aarch64Features, fcma)
-DECLARE_SETTER(Aarch64Features, lrcpc)
-DECLARE_SETTER(Aarch64Features, dcpop)
-DECLARE_SETTER(Aarch64Features, sha3)
-DECLARE_SETTER(Aarch64Features, sm3)
-DECLARE_SETTER(Aarch64Features, sm4)
-DECLARE_SETTER(Aarch64Features, asimddp)
-DECLARE_SETTER(Aarch64Features, sha512)
-DECLARE_SETTER(Aarch64Features, sve)
-DECLARE_SETTER(Aarch64Features, asimdfhm)
-DECLARE_SETTER(Aarch64Features, dit)
-DECLARE_SETTER(Aarch64Features, uscat)
-DECLARE_SETTER(Aarch64Features, ilrcpc)
-DECLARE_SETTER(Aarch64Features, flagm)
-DECLARE_SETTER(Aarch64Features, ssbs)
-DECLARE_SETTER(Aarch64Features, sb)
-DECLARE_SETTER(Aarch64Features, paca)
-DECLARE_SETTER(Aarch64Features, pacg)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, fp)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, asimd)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, evtstrm)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, aes)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, pmull)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, sha1)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, sha2)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, crc32)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, atomics)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, fphp)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, asimdhp)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, cpuid)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, asimdrdm)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, jscvt)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, fcma)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, lrcpc)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, dcpop)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, sha3)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, sm3)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, sm4)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, asimddp)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, sha512)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, sve)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, asimdfhm)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, dit)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, uscat)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, ilrcpc)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, flagm)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, ssbs)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, sb)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, paca)
+DECLARE_SETTER_AND_GETTER(Aarch64Features, pacg)
 
 static const CapabilityConfig kConfigs[] = {
-  [AARCH64_FP] = {{AARCH64_HWCAP_FP, 0}, "fp", &set_fp},
-  [AARCH64_ASIMD] = {{AARCH64_HWCAP_ASIMD, 0}, "asimd", &set_asimd},
-  [AARCH64_EVTSTRM] = {{AARCH64_HWCAP_EVTSTRM, 0}, "evtstrm", &set_evtstrm},
-  [AARCH64_AES] = {{AARCH64_HWCAP_AES, 0}, "aes", &set_aes},
-  [AARCH64_PMULL] = {{AARCH64_HWCAP_PMULL, 0}, "pmull", &set_pmull},
-  [AARCH64_SHA1] = {{AARCH64_HWCAP_SHA1, 0}, "sha1", &set_sha1},
-  [AARCH64_SHA2] = {{AARCH64_HWCAP_SHA2, 0}, "sha2", &set_sha2},
-  [AARCH64_CRC32] = {{AARCH64_HWCAP_CRC32, 0}, "crc32", &set_crc32},
-  [AARCH64_ATOMICS] = {{AARCH64_HWCAP_ATOMICS, 0}, "atomics", &set_atomics},
-  [AARCH64_FPHP] = {{AARCH64_HWCAP_FPHP, 0}, "fphp", &set_fphp},
-  [AARCH64_ASIMDHP] = {{AARCH64_HWCAP_ASIMDHP, 0}, "asimdhp", &set_asimdhp},
-  [AARCH64_CPUID] = {{AARCH64_HWCAP_CPUID, 0}, "cpuid", &set_cpuid},
-  [AARCH64_ASIMDRDM] = {{AARCH64_HWCAP_ASIMDRDM, 0}, "asimdrdm", &set_asimdrdm},
-  [AARCH64_JSCVT] = {{AARCH64_HWCAP_JSCVT, 0}, "jscvt", &set_jscvt},
-  [AARCH64_FCMA] = {{AARCH64_HWCAP_FCMA, 0}, "fcma", &set_fcma},
-  [AARCH64_LRCPC] = {{AARCH64_HWCAP_LRCPC, 0}, "lrcpc", &set_lrcpc},
-  [AARCH64_DCPOP] = {{AARCH64_HWCAP_DCPOP, 0}, "dcpop", &set_dcpop},
-  [AARCH64_SHA3] = {{AARCH64_HWCAP_SHA3, 0}, "sha3", &set_sha3},
-  [AARCH64_SM3] = {{AARCH64_HWCAP_SM3, 0}, "sm3", &set_sm3},
-  [AARCH64_SM4] = {{AARCH64_HWCAP_SM4, 0}, "sm4", &set_sm4},
-  [AARCH64_ASIMDDP] = {{AARCH64_HWCAP_ASIMDDP, 0}, "asimddp", &set_asimddp},
-  [AARCH64_SHA512] = {{AARCH64_HWCAP_SHA512, 0}, "sha512", &set_sha512},
-  [AARCH64_SVE] = {{AARCH64_HWCAP_SVE, 0}, "sve", &set_sve},
-  [AARCH64_ASIMDFHM] = {{AARCH64_HWCAP_ASIMDFHM, 0}, "asimdfhm", &set_asimdfhm},
-  [AARCH64_DIT] = {{AARCH64_HWCAP_DIT, 0}, "dit", &set_dit},
-  [AARCH64_USCAT] = {{AARCH64_HWCAP_USCAT, 0}, "uscat", &set_uscat},
-  [AARCH64_ILRCPC] = {{AARCH64_HWCAP_ILRCPC, 0}, "ilrcpc", &set_ilrcpc},
-  [AARCH64_FLAGM] = {{AARCH64_HWCAP_FLAGM, 0}, "flagm", &set_flagm},
-  [AARCH64_SSBS] = {{AARCH64_HWCAP_SSBS, 0}, "ssbs", &set_ssbs},
-  [AARCH64_SB] = {{AARCH64_HWCAP_SB, 0}, "sb", &set_sb},
-  [AARCH64_PACA] = {{AARCH64_HWCAP_PACA, 0}, "paca", &set_paca},
-  [AARCH64_PACG] = {{AARCH64_HWCAP_PACG, 0}, "pacg", &set_pacg},
+  [AARCH64_FP] = {{AARCH64_HWCAP_FP, 0}, "fp", &set_fp, &get_fp},
+  [AARCH64_ASIMD] = {{AARCH64_HWCAP_ASIMD, 0}, "asimd", &set_asimd, &get_asimd},
+  [AARCH64_EVTSTRM] = {{AARCH64_HWCAP_EVTSTRM, 0}, "evtstrm", &set_evtstrm, &get_evtstrm},
+  [AARCH64_AES] = {{AARCH64_HWCAP_AES, 0}, "aes", &set_aes, &get_aes},
+  [AARCH64_PMULL] = {{AARCH64_HWCAP_PMULL, 0}, "pmull", &set_pmull, &get_pmull},
+  [AARCH64_SHA1] = {{AARCH64_HWCAP_SHA1, 0}, "sha1", &set_sha1, &get_sha1},
+  [AARCH64_SHA2] = {{AARCH64_HWCAP_SHA2, 0}, "sha2", &set_sha2, &get_sha2},
+  [AARCH64_CRC32] = {{AARCH64_HWCAP_CRC32, 0}, "crc32", &set_crc32, &get_crc32},
+  [AARCH64_ATOMICS] = {{AARCH64_HWCAP_ATOMICS, 0}, "atomics", &set_atomics, &get_atomics},
+  [AARCH64_FPHP] = {{AARCH64_HWCAP_FPHP, 0}, "fphp", &set_fphp, &get_fphp},
+  [AARCH64_ASIMDHP] = {{AARCH64_HWCAP_ASIMDHP, 0}, "asimdhp", &set_asimdhp, &get_asimdhp},
+  [AARCH64_CPUID] = {{AARCH64_HWCAP_CPUID, 0}, "cpuid", &set_cpuid, &get_cpuid},
+  [AARCH64_ASIMDRDM] = {{AARCH64_HWCAP_ASIMDRDM, 0}, "asimdrdm", &set_asimdrdm, &get_asimdrdm},
+  [AARCH64_JSCVT] = {{AARCH64_HWCAP_JSCVT, 0}, "jscvt", &set_jscvt, &get_jscvt},
+  [AARCH64_FCMA] = {{AARCH64_HWCAP_FCMA, 0}, "fcma", &set_fcma, &get_fcma},
+  [AARCH64_LRCPC] = {{AARCH64_HWCAP_LRCPC, 0}, "lrcpc", &set_lrcpc, &get_lrcpc},
+  [AARCH64_DCPOP] = {{AARCH64_HWCAP_DCPOP, 0}, "dcpop", &set_dcpop, &get_dcpop},
+  [AARCH64_SHA3] = {{AARCH64_HWCAP_SHA3, 0}, "sha3", &set_sha3, &get_sha3},
+  [AARCH64_SM3] = {{AARCH64_HWCAP_SM3, 0}, "sm3", &set_sm3, &get_sm3},
+  [AARCH64_SM4] = {{AARCH64_HWCAP_SM4, 0}, "sm4", &set_sm4, &get_sm4},
+  [AARCH64_ASIMDDP] = {{AARCH64_HWCAP_ASIMDDP, 0}, "asimddp", &set_asimddp, &get_asimddp},
+  [AARCH64_SHA512] = {{AARCH64_HWCAP_SHA512, 0}, "sha512", &set_sha512, &get_sha512},
+  [AARCH64_SVE] = {{AARCH64_HWCAP_SVE, 0}, "sve", &set_sve, &get_sve},
+  [AARCH64_ASIMDFHM] = {{AARCH64_HWCAP_ASIMDFHM, 0}, "asimdfhm", &set_asimdfhm, &get_asimdfhm},
+  [AARCH64_DIT] = {{AARCH64_HWCAP_DIT, 0}, "dit", &set_dit, &get_dit},
+  [AARCH64_USCAT] = {{AARCH64_HWCAP_USCAT, 0}, "uscat", &set_uscat, &get_uscat},
+  [AARCH64_ILRCPC] = {{AARCH64_HWCAP_ILRCPC, 0}, "ilrcpc", &set_ilrcpc, &get_ilrcpc},
+  [AARCH64_FLAGM] = {{AARCH64_HWCAP_FLAGM, 0}, "flagm", &set_flagm, &get_flagm},
+  [AARCH64_SSBS] = {{AARCH64_HWCAP_SSBS, 0}, "ssbs", &set_ssbs, &get_ssbs},
+  [AARCH64_SB] = {{AARCH64_HWCAP_SB, 0}, "sb", &set_sb, &get_sb},
+  [AARCH64_PACA] = {{AARCH64_HWCAP_PACA, 0}, "paca", &set_paca, &get_paca},
+  [AARCH64_PACG] = {{AARCH64_HWCAP_PACG, 0}, "pacg", &set_pacg, &get_pacg},
 };
 
 static const size_t kConfigsSize = sizeof(kConfigs) / sizeof(CapabilityConfig);
@@ -150,75 +150,9 @@ Aarch64Info GetAarch64Info(void) {
 
 int GetAarch64FeaturesEnumValue(const Aarch64Features* features,
                                 Aarch64FeaturesEnum value) {
-  switch (value) {
-    case AARCH64_FP:
-      return features->fp;
-    case AARCH64_ASIMD:
-      return features->asimd;
-    case AARCH64_EVTSTRM:
-      return features->evtstrm;
-    case AARCH64_AES:
-      return features->aes;
-    case AARCH64_PMULL:
-      return features->pmull;
-    case AARCH64_SHA1:
-      return features->sha1;
-    case AARCH64_SHA2:
-      return features->sha2;
-    case AARCH64_CRC32:
-      return features->crc32;
-    case AARCH64_ATOMICS:
-      return features->atomics;
-    case AARCH64_FPHP:
-      return features->fphp;
-    case AARCH64_ASIMDHP:
-      return features->asimdhp;
-    case AARCH64_CPUID:
-      return features->cpuid;
-    case AARCH64_ASIMDRDM:
-      return features->asimdrdm;
-    case AARCH64_JSCVT:
-      return features->jscvt;
-    case AARCH64_FCMA:
-      return features->fcma;
-    case AARCH64_LRCPC:
-      return features->lrcpc;
-    case AARCH64_DCPOP:
-      return features->dcpop;
-    case AARCH64_SHA3:
-      return features->sha3;
-    case AARCH64_SM3:
-      return features->sm3;
-    case AARCH64_SM4:
-      return features->sm4;
-    case AARCH64_ASIMDDP:
-      return features->asimddp;
-    case AARCH64_SHA512:
-      return features->sha512;
-    case AARCH64_SVE:
-      return features->sve;
-    case AARCH64_ASIMDFHM:
-      return features->asimdfhm;
-    case AARCH64_DIT:
-      return features->dit;
-    case AARCH64_USCAT:
-      return features->uscat;
-    case AARCH64_ILRCPC:
-      return features->ilrcpc;
-    case AARCH64_FLAGM:
-      return features->flagm;
-    case AARCH64_SSBS:
-      return features->ssbs;
-    case AARCH64_SB:
-      return features->sb;
-    case AARCH64_PACA:
-      return features->paca;
-    case AARCH64_PACG:
-      return features->pacg;
-    case AARCH64_LAST_:
-      break;
-  }
-  return false;
+  if(value >= kConfigsSize)
+    return false;
+  return kConfigs[value].get_bit((Aarch64Features*)features);
 }
 
 const char* GetAarch64FeaturesEnumName(Aarch64FeaturesEnum value) {

--- a/src/cpuinfo_arm.c
+++ b/src/cpuinfo_arm.c
@@ -24,62 +24,62 @@
 #include <assert.h>
 #include <ctype.h>
 
-DECLARE_SETTER(ArmFeatures, swp)
-DECLARE_SETTER(ArmFeatures, half)
-DECLARE_SETTER(ArmFeatures, thumb)
-DECLARE_SETTER(ArmFeatures, _26bit)
-DECLARE_SETTER(ArmFeatures, fastmult)
-DECLARE_SETTER(ArmFeatures, fpa)
-DECLARE_SETTER(ArmFeatures, vfp)
-DECLARE_SETTER(ArmFeatures, edsp)
-DECLARE_SETTER(ArmFeatures, java)
-DECLARE_SETTER(ArmFeatures, iwmmxt)
-DECLARE_SETTER(ArmFeatures, crunch)
-DECLARE_SETTER(ArmFeatures, thumbee)
-DECLARE_SETTER(ArmFeatures, neon)
-DECLARE_SETTER(ArmFeatures, vfpv3)
-DECLARE_SETTER(ArmFeatures, vfpv3d16)
-DECLARE_SETTER(ArmFeatures, tls)
-DECLARE_SETTER(ArmFeatures, vfpv4)
-DECLARE_SETTER(ArmFeatures, idiva)
-DECLARE_SETTER(ArmFeatures, idivt)
-DECLARE_SETTER(ArmFeatures, vfpd32)
-DECLARE_SETTER(ArmFeatures, lpae)
-DECLARE_SETTER(ArmFeatures, evtstrm)
-DECLARE_SETTER(ArmFeatures, aes)
-DECLARE_SETTER(ArmFeatures, pmull)
-DECLARE_SETTER(ArmFeatures, sha1)
-DECLARE_SETTER(ArmFeatures, sha2)
-DECLARE_SETTER(ArmFeatures, crc32)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, swp)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, half)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, thumb)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, _26bit)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, fastmult)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, fpa)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, vfp)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, edsp)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, java)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, iwmmxt)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, crunch)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, thumbee)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, neon)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, vfpv3)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, vfpv3d16)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, tls)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, vfpv4)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, idiva)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, idivt)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, vfpd32)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, lpae)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, evtstrm)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, aes)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, pmull)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, sha1)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, sha2)
+DECLARE_SETTER_AND_GETTER(ArmFeatures, crc32)
 
 static const CapabilityConfig kConfigs[] = {
-  [ARM_SWP] = {{ARM_HWCAP_SWP, 0}, "swp", &set_swp},                      //
-  [ARM_HALF] = {{ARM_HWCAP_HALF, 0}, "half", &set_half},                  //
-  [ARM_THUMB] = {{ARM_HWCAP_THUMB, 0}, "thumb", &set_thumb},              //
-  [ARM_26BIT] = {{ARM_HWCAP_26BIT, 0}, "26bit", &set__26bit},             //
-  [ARM_FASTMULT] = {{ARM_HWCAP_FAST_MULT, 0}, "fastmult", &set_fastmult}, //
-  [ARM_FPA] = {{ARM_HWCAP_FPA, 0}, "fpa", &set_fpa},                      //
-  [ARM_VFP] = {{ARM_HWCAP_VFP, 0}, "vfp", &set_vfp},                      //
-  [ARM_EDSP] = {{ARM_HWCAP_EDSP, 0}, "edsp", &set_edsp},                  //
-  [ARM_JAVA] = {{ARM_HWCAP_JAVA, 0}, "java", &set_java},                  //
-  [ARM_IWMMXT] = {{ARM_HWCAP_IWMMXT, 0}, "iwmmxt", &set_iwmmxt},          //
-  [ARM_CRUNCH] = {{ARM_HWCAP_CRUNCH, 0}, "crunch", &set_crunch},          //
-  [ARM_THUMBEE] = {{ARM_HWCAP_THUMBEE, 0}, "thumbee", &set_thumbee},      //
-  [ARM_NEON] = {{ARM_HWCAP_NEON, 0}, "neon", &set_neon},                  //
-  [ARM_VFPV3] = {{ARM_HWCAP_VFPV3, 0}, "vfpv3", &set_vfpv3},              //
-  [ARM_VFPV3D16] = {{ARM_HWCAP_VFPV3D16, 0}, "vfpv3d16", &set_vfpv3d16},  //
-  [ARM_TLS] = {{ARM_HWCAP_TLS, 0}, "tls", &set_tls},                      //
-  [ARM_VFPV4] = {{ARM_HWCAP_VFPV4, 0}, "vfpv4", &set_vfpv4},              //
-  [ARM_IDIVA] = {{ARM_HWCAP_IDIVA, 0}, "idiva", &set_idiva},              //
-  [ARM_IDIVT] = {{ARM_HWCAP_IDIVT, 0}, "idivt", &set_idivt},              //
-  [ARM_VFPD32] = {{ARM_HWCAP_VFPD32, 0}, "vfpd32", &set_vfpd32},          //
-  [ARM_LPAE] = {{ARM_HWCAP_LPAE, 0}, "lpae", &set_lpae},                  //
-  [ARM_EVTSTRM] = {{ARM_HWCAP_EVTSTRM, 0}, "evtstrm", &set_evtstrm},      //
-  [ARM_AES] = {{0, ARM_HWCAP2_AES}, "aes", &set_aes},                     //
-  [ARM_PMULL] = {{0, ARM_HWCAP2_PMULL}, "pmull", &set_pmull},             //
-  [ARM_SHA1] = {{0, ARM_HWCAP2_SHA1}, "sha1", &set_sha1},                 //
-  [ARM_SHA2] = {{0, ARM_HWCAP2_SHA2}, "sha2", &set_sha2},                 //
-  [ARM_CRC32] = {{0, ARM_HWCAP2_CRC32}, "crc32", &set_crc32},             //
+  [ARM_SWP] = {{ARM_HWCAP_SWP, 0}, "swp", &set_swp, &get_swp},                           //
+  [ARM_HALF] = {{ARM_HWCAP_HALF, 0}, "half", &set_half, &get_half},                      //
+  [ARM_THUMB] = {{ARM_HWCAP_THUMB, 0}, "thumb", &set_thumb, &get_thumb},                 //
+  [ARM_26BIT] = {{ARM_HWCAP_26BIT, 0}, "26bit", &set__26bit, &get__26bit},               //
+  [ARM_FASTMULT] = {{ARM_HWCAP_FAST_MULT, 0}, "fastmult", &set_fastmult, &get_fastmult}, //
+  [ARM_FPA] = {{ARM_HWCAP_FPA, 0}, "fpa", &set_fpa, &get_fpa},                           //
+  [ARM_VFP] = {{ARM_HWCAP_VFP, 0}, "vfp", &set_vfp, &get_vfp},                           //
+  [ARM_EDSP] = {{ARM_HWCAP_EDSP, 0}, "edsp", &set_edsp, &get_edsp},                      //
+  [ARM_JAVA] = {{ARM_HWCAP_JAVA, 0}, "java", &set_java, &get_java},                      //
+  [ARM_IWMMXT] = {{ARM_HWCAP_IWMMXT, 0}, "iwmmxt", &set_iwmmxt, &get_iwmmxt},            //
+  [ARM_CRUNCH] = {{ARM_HWCAP_CRUNCH, 0}, "crunch", &set_crunch, &get_crunch},            //
+  [ARM_THUMBEE] = {{ARM_HWCAP_THUMBEE, 0}, "thumbee", &set_thumbee, &get_thumbee},       //
+  [ARM_NEON] = {{ARM_HWCAP_NEON, 0}, "neon", &set_neon, &get_neon},                      //
+  [ARM_VFPV3] = {{ARM_HWCAP_VFPV3, 0}, "vfpv3", &set_vfpv3, &get_vfpv3},                 //
+  [ARM_VFPV3D16] = {{ARM_HWCAP_VFPV3D16, 0}, "vfpv3d16", &set_vfpv3d16, &get_vfpv3d16},  //
+  [ARM_TLS] = {{ARM_HWCAP_TLS, 0}, "tls", &set_tls, &get_tls},                           //
+  [ARM_VFPV4] = {{ARM_HWCAP_VFPV4, 0}, "vfpv4", &set_vfpv4, &get_vfpv4},                 //
+  [ARM_IDIVA] = {{ARM_HWCAP_IDIVA, 0}, "idiva", &set_idiva, &get_idiva},                 //
+  [ARM_IDIVT] = {{ARM_HWCAP_IDIVT, 0}, "idivt", &set_idivt, &get_idivt},                 //
+  [ARM_VFPD32] = {{ARM_HWCAP_VFPD32, 0}, "vfpd32", &set_vfpd32, &get_vfpd32},            //
+  [ARM_LPAE] = {{ARM_HWCAP_LPAE, 0}, "lpae", &set_lpae, &get_lpae},                      //
+  [ARM_EVTSTRM] = {{ARM_HWCAP_EVTSTRM, 0}, "evtstrm", &set_evtstrm, &get_evtstrm},       //
+  [ARM_AES] = {{0, ARM_HWCAP2_AES}, "aes", &set_aes, &get_aes},                          //
+  [ARM_PMULL] = {{0, ARM_HWCAP2_PMULL}, "pmull", &set_pmull, &get_pmull},                //
+  [ARM_SHA1] = {{0, ARM_HWCAP2_SHA1}, "sha1", &set_sha1, &get_sha1},                     //
+  [ARM_SHA2] = {{0, ARM_HWCAP2_SHA2}, "sha2", &set_sha2, &get_sha2},                     //
+  [ARM_CRC32] = {{0, ARM_HWCAP2_CRC32}, "crc32", &set_crc32, &get_crc32},                //
 };
 
 static const size_t kConfigsSize = sizeof(kConfigs) / sizeof(CapabilityConfig);
@@ -224,65 +224,9 @@ ArmInfo GetArmInfo(void) {
 
 int GetArmFeaturesEnumValue(const ArmFeatures* features,
                             ArmFeaturesEnum value) {
-  switch (value) {
-    case ARM_SWP:
-      return features->swp;
-    case ARM_HALF:
-      return features->half;
-    case ARM_THUMB:
-      return features->thumb;
-    case ARM_26BIT:
-      return features->_26bit;
-    case ARM_FASTMULT:
-      return features->fastmult;
-    case ARM_FPA:
-      return features->fpa;
-    case ARM_VFP:
-      return features->vfp;
-    case ARM_EDSP:
-      return features->edsp;
-    case ARM_JAVA:
-      return features->java;
-    case ARM_IWMMXT:
-      return features->iwmmxt;
-    case ARM_CRUNCH:
-      return features->crunch;
-    case ARM_THUMBEE:
-      return features->thumbee;
-    case ARM_NEON:
-      return features->neon;
-    case ARM_VFPV3:
-      return features->vfpv3;
-    case ARM_VFPV3D16:
-      return features->vfpv3d16;
-    case ARM_TLS:
-      return features->tls;
-    case ARM_VFPV4:
-      return features->vfpv4;
-    case ARM_IDIVA:
-      return features->idiva;
-    case ARM_IDIVT:
-      return features->idivt;
-    case ARM_VFPD32:
-      return features->vfpd32;
-    case ARM_LPAE:
-      return features->lpae;
-    case ARM_EVTSTRM:
-      return features->evtstrm;
-    case ARM_AES:
-      return features->aes;
-    case ARM_PMULL:
-      return features->pmull;
-    case ARM_SHA1:
-      return features->sha1;
-    case ARM_SHA2:
-      return features->sha2;
-    case ARM_CRC32:
-      return features->crc32;
-    case ARM_LAST_:
-      break;
-  }
-  return false;
+  if(value >= kConfigsSize)
+    return false;
+  return kConfigs[value].get_bit((ArmFeatures*)features);
 }
 
 const char* GetArmFeaturesEnumName(ArmFeaturesEnum value) {

--- a/src/cpuinfo_mips.c
+++ b/src/cpuinfo_mips.c
@@ -21,14 +21,14 @@
 
 #include <assert.h>
 
-DECLARE_SETTER(MipsFeatures, msa)
-DECLARE_SETTER(MipsFeatures, eva)
-DECLARE_SETTER(MipsFeatures, r6)
+DECLARE_SETTER_AND_GETTER(MipsFeatures, msa)
+DECLARE_SETTER_AND_GETTER(MipsFeatures, eva)
+DECLARE_SETTER_AND_GETTER(MipsFeatures, r6)
 
 static const CapabilityConfig kConfigs[] = {
-  [MIPS_MSA] = {{MIPS_HWCAP_MSA, 0}, "msa", &set_msa},  //
-  [MIPS_EVA] = {{0, 0}, "eva", &set_eva},               //
-  [MIPS_R6] = {{MIPS_HWCAP_R6, 0}, "r6", &set_r6},      //
+  [MIPS_MSA] = {{MIPS_HWCAP_MSA, 0}, "msa", &set_msa, &get_msa},  //
+  [MIPS_EVA] = {{0, 0}, "eva", &set_eva, &get_eva},               //
+  [MIPS_R6] = {{MIPS_HWCAP_R6, 0}, "r6", &set_r6, &get_r6},       //
 };
 static const size_t kConfigsSize = sizeof(kConfigs) / sizeof(CapabilityConfig);
 
@@ -80,17 +80,9 @@ MipsInfo GetMipsInfo(void) {
 
 int GetMipsFeaturesEnumValue(const MipsFeatures* features,
                              MipsFeaturesEnum value) {
-  switch (value) {
-    case MIPS_MSA:
-      return features->msa;
-    case MIPS_EVA:
-      return features->eva;
-    case MIPS_R6:
-      return features->r6;
-    case MIPS_LAST_:
-      break;
-  }
-  return false;
+  if(value >= kConfigsSize)
+    return false;
+  return kConfigs[value].get_bit((MipsFeatures*)features);
 }
 
 const char* GetMipsFeaturesEnumName(MipsFeaturesEnum value) {

--- a/src/cpuinfo_ppc.c
+++ b/src/cpuinfo_ppc.c
@@ -23,92 +23,92 @@
 #include "internal/string_view.h"
 #include "internal/unix_features_aggregator.h"
 
-DECLARE_SETTER(PPCFeatures, ppc32)
-DECLARE_SETTER(PPCFeatures, ppc64)
-DECLARE_SETTER(PPCFeatures, ppc601)
-DECLARE_SETTER(PPCFeatures, altivec)
-DECLARE_SETTER(PPCFeatures, fpu)
-DECLARE_SETTER(PPCFeatures, mmu)
-DECLARE_SETTER(PPCFeatures, mac_4xx)
-DECLARE_SETTER(PPCFeatures, unifiedcache)
-DECLARE_SETTER(PPCFeatures, spe)
-DECLARE_SETTER(PPCFeatures, efpsingle)
-DECLARE_SETTER(PPCFeatures, efpdouble)
-DECLARE_SETTER(PPCFeatures, no_tb)
-DECLARE_SETTER(PPCFeatures, power4)
-DECLARE_SETTER(PPCFeatures, power5)
-DECLARE_SETTER(PPCFeatures, power5plus)
-DECLARE_SETTER(PPCFeatures, cell)
-DECLARE_SETTER(PPCFeatures, booke)
-DECLARE_SETTER(PPCFeatures, smt)
-DECLARE_SETTER(PPCFeatures, icachesnoop)
-DECLARE_SETTER(PPCFeatures, arch205)
-DECLARE_SETTER(PPCFeatures, pa6t)
-DECLARE_SETTER(PPCFeatures, dfp)
-DECLARE_SETTER(PPCFeatures, power6ext)
-DECLARE_SETTER(PPCFeatures, arch206)
-DECLARE_SETTER(PPCFeatures, vsx)
-DECLARE_SETTER(PPCFeatures, pseries_perfmon_compat)
-DECLARE_SETTER(PPCFeatures, truele)
-DECLARE_SETTER(PPCFeatures, ppcle)
-DECLARE_SETTER(PPCFeatures, arch207)
-DECLARE_SETTER(PPCFeatures, htm)
-DECLARE_SETTER(PPCFeatures, dscr)
-DECLARE_SETTER(PPCFeatures, ebb)
-DECLARE_SETTER(PPCFeatures, isel)
-DECLARE_SETTER(PPCFeatures, tar)
-DECLARE_SETTER(PPCFeatures, vcrypto)
-DECLARE_SETTER(PPCFeatures, htm_nosc)
-DECLARE_SETTER(PPCFeatures, arch300)
-DECLARE_SETTER(PPCFeatures, ieee128)
-DECLARE_SETTER(PPCFeatures, darn)
-DECLARE_SETTER(PPCFeatures, scv)
-DECLARE_SETTER(PPCFeatures, htm_no_suspend)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, ppc32)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, ppc64)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, ppc601)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, altivec)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, fpu)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, mmu)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, mac_4xx)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, unifiedcache)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, spe)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, efpsingle)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, efpdouble)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, no_tb)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, power4)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, power5)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, power5plus)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, cell)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, booke)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, smt)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, icachesnoop)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, arch205)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, pa6t)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, dfp)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, power6ext)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, arch206)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, vsx)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, pseries_perfmon_compat)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, truele)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, ppcle)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, arch207)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, htm)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, dscr)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, ebb)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, isel)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, tar)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, vcrypto)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, htm_nosc)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, arch300)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, ieee128)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, darn)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, scv)
+DECLARE_SETTER_AND_GETTER(PPCFeatures, htm_no_suspend)
 
 static const CapabilityConfig kConfigs[] = {
-  [PPC_32] = {{PPC_FEATURE_32, 0}, "ppc32", &set_ppc32},
-  [PPC_64] = {{PPC_FEATURE_64, 0}, "ppc64", &set_ppc64},
-  [PPC_601_INSTR] = {{PPC_FEATURE_601_INSTR, 0}, "ppc601", &set_ppc601},
-  [PPC_HAS_ALTIVEC] = {{PPC_FEATURE_HAS_ALTIVEC, 0}, "altivec", &set_altivec},
-  [PPC_HAS_FPU] = {{PPC_FEATURE_HAS_FPU, 0}, "fpu", &set_fpu},
-  [PPC_HAS_MMU] = {{PPC_FEATURE_HAS_MMU, 0}, "mmu", &set_mmu},
-  [PPC_HAS_4xxMAC] = {{PPC_FEATURE_HAS_4xxMAC, 0}, "4xxmac", &set_mac_4xx},
-  [PPC_UNIFIED_CACHE] = {{PPC_FEATURE_UNIFIED_CACHE, 0}, "ucache", &set_unifiedcache},
-  [PPC_HAS_SPE] = {{PPC_FEATURE_HAS_SPE, 0}, "spe", &set_spe},
-  [PPC_HAS_EFP_SINGLE] = {{PPC_FEATURE_HAS_EFP_SINGLE, 0}, "efpsingle", &set_efpsingle},
-  [PPC_HAS_EFP_DOUBLE] = {{PPC_FEATURE_HAS_EFP_DOUBLE, 0}, "efpdouble", &set_efpdouble},
-  [PPC_NO_TB] = {{PPC_FEATURE_NO_TB, 0}, "notb", &set_no_tb},
-  [PPC_POWER4] = {{PPC_FEATURE_POWER4, 0}, "power4", &set_power4},
-  [PPC_POWER5] = {{PPC_FEATURE_POWER5, 0}, "power5", &set_power5},
-  [PPC_POWER5_PLUS] = {{PPC_FEATURE_POWER5_PLUS, 0}, "power5+", &set_power5plus},
-  [PPC_CELL] = {{PPC_FEATURE_CELL, 0}, "cellbe", &set_cell},
-  [PPC_BOOKE] = {{PPC_FEATURE_BOOKE, 0}, "booke", &set_booke},
-  [PPC_SMT] = {{PPC_FEATURE_SMT, 0}, "smt", &set_smt},
-  [PPC_ICACHE_SNOOP] = {{PPC_FEATURE_ICACHE_SNOOP, 0}, "ic_snoop", &set_icachesnoop},
-  [PPC_ARCH_2_05] = {{PPC_FEATURE_ARCH_2_05, 0}, "arch_2_05", &set_arch205},
-  [PPC_PA6T] = {{PPC_FEATURE_PA6T, 0}, "pa6t", &set_pa6t},
-  [PPC_HAS_DFP] = {{PPC_FEATURE_HAS_DFP, 0}, "dfp", &set_dfp},
-  [PPC_POWER6_EXT] = {{PPC_FEATURE_POWER6_EXT, 0}, "power6x", &set_power6ext},
-  [PPC_ARCH_2_06] = {{PPC_FEATURE_ARCH_2_06, 0}, "arch_2_06", &set_arch206},
-  [PPC_HAS_VSX] = {{PPC_FEATURE_HAS_VSX, 0}, "vsx", &set_vsx},
-  [PPC_PSERIES_PERFMON_COMPAT] = {{PPC_FEATURE_PSERIES_PERFMON_COMPAT, 0},
-     "archpmu",
-     &set_pseries_perfmon_compat},
-  [PPC_TRUE_LE] = {{PPC_FEATURE_TRUE_LE, 0}, "true_le", &set_truele},
-  [PPC_PPC_LE] = {{PPC_FEATURE_PPC_LE, 0}, "ppcle", &set_ppcle},
-  [PPC_ARCH_2_07] = {{0, PPC_FEATURE2_ARCH_2_07}, "arch_2_07", &set_arch207},
-  [PPC_HTM] = {{0, PPC_FEATURE2_HTM}, "htm", &set_htm},
-  [PPC_DSCR] = {{0, PPC_FEATURE2_DSCR}, "dscr", &set_dscr},
-  [PPC_EBB] = {{0, PPC_FEATURE2_EBB}, "ebb", &set_ebb},
-  [PPC_ISEL] = {{0, PPC_FEATURE2_ISEL}, "isel", &set_isel},
-  [PPC_TAR] = {{0, PPC_FEATURE2_TAR}, "tar", &set_tar},
-  [PPC_VEC_CRYPTO] = {{0, PPC_FEATURE2_VEC_CRYPTO}, "vcrypto", &set_vcrypto},
-  [PPC_HTM_NOSC] = {{0, PPC_FEATURE2_HTM_NOSC}, "htm-nosc", &set_htm_nosc},
-  [PPC_ARCH_3_00] = {{0, PPC_FEATURE2_ARCH_3_00}, "arch_3_00", &set_arch300},
-  [PPC_HAS_IEEE128] = {{0, PPC_FEATURE2_HAS_IEEE128}, "ieee128", &set_ieee128},
-  [PPC_DARN] = {{0, PPC_FEATURE2_DARN}, "darn", &set_darn},
-  [PPC_SCV] = {{0, PPC_FEATURE2_SCV}, "scv", &set_scv},
-  [PPC_HTM_NO_SUSPEND] = {{0, PPC_FEATURE2_HTM_NO_SUSPEND}, "htm-no-suspend", &set_htm_no_suspend},
+  [PPC_32] = {{PPC_FEATURE_32, 0}, "ppc32", &set_ppc32, &get_ppc32},
+  [PPC_64] = {{PPC_FEATURE_64, 0}, "ppc64", &set_ppc64, &get_ppc64},
+  [PPC_601_INSTR] = {{PPC_FEATURE_601_INSTR, 0}, "ppc601", &set_ppc601, &get_ppc601},
+  [PPC_HAS_ALTIVEC] = {{PPC_FEATURE_HAS_ALTIVEC, 0}, "altivec", &set_altivec, &get_altivec},
+  [PPC_HAS_FPU] = {{PPC_FEATURE_HAS_FPU, 0}, "fpu", &set_fpu, &get_fpu},
+  [PPC_HAS_MMU] = {{PPC_FEATURE_HAS_MMU, 0}, "mmu", &set_mmu, &get_mmu},
+  [PPC_HAS_4xxMAC] = {{PPC_FEATURE_HAS_4xxMAC, 0}, "4xxmac", &set_mac_4xx, &get_mac_4xx},
+  [PPC_UNIFIED_CACHE] = {{PPC_FEATURE_UNIFIED_CACHE, 0}, "ucache", &set_unifiedcache, &get_unifiedcache},
+  [PPC_HAS_SPE] = {{PPC_FEATURE_HAS_SPE, 0}, "spe", &set_spe, &get_spe},
+  [PPC_HAS_EFP_SINGLE] = {{PPC_FEATURE_HAS_EFP_SINGLE, 0}, "efpsingle", &set_efpsingle, &get_efpsingle},
+  [PPC_HAS_EFP_DOUBLE] = {{PPC_FEATURE_HAS_EFP_DOUBLE, 0}, "efpdouble", &set_efpdouble, &get_efpdouble},
+  [PPC_NO_TB] = {{PPC_FEATURE_NO_TB, 0}, "notb", &set_no_tb, &get_no_tb},
+  [PPC_POWER4] = {{PPC_FEATURE_POWER4, 0}, "power4", &set_power4, &get_power4},
+  [PPC_POWER5] = {{PPC_FEATURE_POWER5, 0}, "power5", &set_power5, &get_power5},
+  [PPC_POWER5_PLUS] = {{PPC_FEATURE_POWER5_PLUS, 0}, "power5+", &set_power5plus, &get_power5plus},
+  [PPC_CELL] = {{PPC_FEATURE_CELL, 0}, "cellbe", &set_cell, &get_cell},
+  [PPC_BOOKE] = {{PPC_FEATURE_BOOKE, 0}, "booke", &set_booke, &get_booke},
+  [PPC_SMT] = {{PPC_FEATURE_SMT, 0}, "smt", &set_smt, &get_smt},
+  [PPC_ICACHE_SNOOP] = {{PPC_FEATURE_ICACHE_SNOOP, 0}, "ic_snoop", &set_icachesnoop, &get_icachesnoop},
+  [PPC_ARCH_2_05] = {{PPC_FEATURE_ARCH_2_05, 0}, "arch_2_05", &set_arch205, &get_arch205},
+  [PPC_PA6T] = {{PPC_FEATURE_PA6T, 0}, "pa6t", &set_pa6t, &get_pa6t},
+  [PPC_HAS_DFP] = {{PPC_FEATURE_HAS_DFP, 0}, "dfp", &set_dfp, &get_dfp},
+  [PPC_POWER6_EXT] = {{PPC_FEATURE_POWER6_EXT, 0}, "power6x", &set_power6ext, &get_power6ext},
+  [PPC_ARCH_2_06] = {{PPC_FEATURE_ARCH_2_06, 0}, "arch_2_06", &set_arch206, &get_arch206},
+  [PPC_HAS_VSX] = {{PPC_FEATURE_HAS_VSX, 0}, "vsx", &set_vsx, &get_vsx},
+  [PPC_PSERIES_PERFMON_COMPAT] = {{PPC_FEATURE_PSERIES_PERFMON_COMPAT, 0}, "archpmu",
+     &set_pseries_perfmon_compat, &get_pseries_perfmon_compat},
+  [PPC_TRUE_LE] = {{PPC_FEATURE_TRUE_LE, 0}, "true_le", &set_truele, &get_truele},
+  [PPC_PPC_LE] = {{PPC_FEATURE_PPC_LE, 0}, "ppcle", &set_ppcle, &get_ppcle},
+  [PPC_ARCH_2_07] = {{0, PPC_FEATURE2_ARCH_2_07}, "arch_2_07", &set_arch207, &get_arch207},
+  [PPC_HTM] = {{0, PPC_FEATURE2_HTM}, "htm", &set_htm, &get_htm},
+  [PPC_DSCR] = {{0, PPC_FEATURE2_DSCR}, "dscr", &set_dscr, &get_dscr},
+  [PPC_EBB] = {{0, PPC_FEATURE2_EBB}, "ebb", &set_ebb, &get_ebb},
+  [PPC_ISEL] = {{0, PPC_FEATURE2_ISEL}, "isel", &set_isel, &get_isel},
+  [PPC_TAR] = {{0, PPC_FEATURE2_TAR}, "tar", &set_tar, &get_tar},
+  [PPC_VEC_CRYPTO] = {{0, PPC_FEATURE2_VEC_CRYPTO}, "vcrypto", &set_vcrypto, &get_vcrypto},
+  [PPC_HTM_NOSC] = {{0, PPC_FEATURE2_HTM_NOSC}, "htm-nosc", &set_htm_nosc, &get_htm_nosc},
+  [PPC_ARCH_3_00] = {{0, PPC_FEATURE2_ARCH_3_00}, "arch_3_00", &set_arch300, &get_arch300},
+  [PPC_HAS_IEEE128] = {{0, PPC_FEATURE2_HAS_IEEE128}, "ieee128", &set_ieee128, &get_ieee128},
+  [PPC_DARN] = {{0, PPC_FEATURE2_DARN}, "darn", &set_darn, &get_darn},
+  [PPC_SCV] = {{0, PPC_FEATURE2_SCV}, "scv", &set_scv, &get_scv},
+  [PPC_HTM_NO_SUSPEND] = {{0, PPC_FEATURE2_HTM_NO_SUSPEND}, "htm-no-suspend", &set_htm_no_suspend,
+     &get_htm_no_suspend},
 };
 static const size_t kConfigsSize = sizeof(kConfigs) / sizeof(CapabilityConfig);
 
@@ -178,96 +178,11 @@ PPCPlatformStrings GetPPCPlatformStrings(void) {
 
 int GetPPCFeaturesEnumValue(const PPCFeatures* features,
                             PPCFeaturesEnum value) {
-  switch (value) {
-    case PPC_32:
-      return features->ppc32;
-    case PPC_64:
-      return features->ppc64;
-    case PPC_601_INSTR:
-      return features->ppc601;
-    case PPC_HAS_ALTIVEC:
-      return features->altivec;
-    case PPC_HAS_FPU:
-      return features->fpu;
-    case PPC_HAS_MMU:
-      return features->mmu;
-    case PPC_HAS_4xxMAC:
-      return features->mac_4xx;
-    case PPC_UNIFIED_CACHE:
-      return features->unifiedcache;
-    case PPC_HAS_SPE:
-      return features->spe;
-    case PPC_HAS_EFP_SINGLE:
-      return features->efpsingle;
-    case PPC_HAS_EFP_DOUBLE:
-      return features->efpdouble;
-    case PPC_NO_TB:
-      return features->no_tb;
-    case PPC_POWER4:
-      return features->power4;
-    case PPC_POWER5:
-      return features->power5;
-    case PPC_POWER5_PLUS:
-      return features->power5plus;
-    case PPC_CELL:
-      return features->cell;
-    case PPC_BOOKE:
-      return features->booke;
-    case PPC_SMT:
-      return features->smt;
-    case PPC_ICACHE_SNOOP:
-      return features->icachesnoop;
-    case PPC_ARCH_2_05:
-      return features->arch205;
-    case PPC_PA6T:
-      return features->pa6t;
-    case PPC_HAS_DFP:
-      return features->dfp;
-    case PPC_POWER6_EXT:
-      return features->power6ext;
-    case PPC_ARCH_2_06:
-      return features->arch206;
-    case PPC_HAS_VSX:
-      return features->vsx;
-    case PPC_PSERIES_PERFMON_COMPAT:
-      return features->pseries_perfmon_compat;
-    case PPC_TRUE_LE:
-      return features->truele;
-    case PPC_PPC_LE:
-      return features->ppcle;
-    case PPC_ARCH_2_07:
-      return features->arch207;
-    case PPC_HTM:
-      return features->htm;
-    case PPC_DSCR:
-      return features->dscr;
-    case PPC_EBB:
-      return features->ebb;
-    case PPC_ISEL:
-      return features->isel;
-    case PPC_TAR:
-      return features->tar;
-    case PPC_VEC_CRYPTO:
-      return features->vcrypto;
-    case PPC_HTM_NOSC:
-      return features->htm_nosc;
-    case PPC_ARCH_3_00:
-      return features->arch300;
-    case PPC_HAS_IEEE128:
-      return features->ieee128;
-    case PPC_DARN:
-      return features->darn;
-    case PPC_SCV:
-      return features->scv;
-    case PPC_HTM_NO_SUSPEND:
-      return features->htm_no_suspend;
-    case PPC_LAST_:
-      break;
-  }
-  return false;
+  if(value >= kConfigsSize)
+    return false;
+  return kConfigs[value].get_bit((PPCFeatures*)features);
 }
 
-/* Have used the same names as glibc  */
 const char* GetPPCFeaturesEnumName(PPCFeaturesEnum value) {
   if(value >= kConfigsSize)
     return "unknown feature";

--- a/test/cpuinfo_arm_test.cc
+++ b/test/cpuinfo_arm_test.cc
@@ -43,6 +43,12 @@ TEST(CpuinfoArmTest, FromHardwareCap) {
   EXPECT_FALSE(info.features.pmull);
   EXPECT_FALSE(info.features.sha1);
   EXPECT_FALSE(info.features.sha2);
+
+  // check some random features with EnumValue():
+  EXPECT_TRUE(GetArmFeaturesEnumValue(&info.features, ARM_VFP));
+  EXPECT_FALSE(GetArmFeaturesEnumValue(&info.features, ARM_VFPV4));
+  // out of bound EnumValue() check
+  EXPECT_FALSE(GetArmFeaturesEnumValue(&info.features, (ArmFeaturesEnum)~0x0));
 }
 
 TEST(CpuinfoArmTest, ODroidFromCpuInfo) {

--- a/test/unix_features_aggregator_test.cc
+++ b/test/unix_features_aggregator_test.cc
@@ -28,16 +28,23 @@ struct Features {
   bool c = false;
 };
 
-DECLARE_SETTER(Features, a)
-DECLARE_SETTER(Features, b)
-DECLARE_SETTER(Features, c)
+enum eFeatures {
+  TEST_a,
+  TEST_b,
+  TEST_c
+};
+
+DECLARE_SETTER_AND_GETTER(Features, a)
+DECLARE_SETTER_AND_GETTER(Features, b)
+DECLARE_SETTER_AND_GETTER(Features, c)
 
 class LinuxFeatureAggregatorTest : public testing::Test {
  public:
-  const std::array<CapabilityConfig, 3> kConfigs = {
-      {{{0b0001, 0b0000}, "a", &set_a},
-       {{0b0010, 0b0000}, "b", &set_b},
-       {{0b0000, 0b1100}, "c", &set_c}}};
+  const std::array<CapabilityConfig, 3> kConfigs = {{
+    {{0b0001, 0b0000}, "a", &set_a, &get_a},
+    {{0b0010, 0b0000}, "b", &set_b, &get_b},
+    {{0b0000, 0b1100}, "c", &set_c, &get_c}
+  }};
 };
 
 TEST_F(LinuxFeatureAggregatorTest, FromFlagsEmpty) {
@@ -47,6 +54,8 @@ TEST_F(LinuxFeatureAggregatorTest, FromFlagsEmpty) {
   EXPECT_FALSE(features.a);
   EXPECT_FALSE(features.b);
   EXPECT_FALSE(features.c);
+
+  EXPECT_FALSE(kConfigs[TEST_a].get_bit(&features));
 }
 
 TEST_F(LinuxFeatureAggregatorTest, FromFlagsAllSet) {
@@ -56,6 +65,8 @@ TEST_F(LinuxFeatureAggregatorTest, FromFlagsAllSet) {
   EXPECT_TRUE(features.a);
   EXPECT_TRUE(features.b);
   EXPECT_TRUE(features.c);
+
+  EXPECT_TRUE(kConfigs[TEST_a].get_bit(&features));
 }
 
 TEST_F(LinuxFeatureAggregatorTest, FromFlagsOnlyA) {
@@ -65,6 +76,10 @@ TEST_F(LinuxFeatureAggregatorTest, FromFlagsOnlyA) {
   EXPECT_TRUE(features.a);
   EXPECT_FALSE(features.b);
   EXPECT_FALSE(features.c);
+
+  EXPECT_TRUE(kConfigs[TEST_a].get_bit(&features));
+  EXPECT_FALSE(kConfigs[TEST_b].get_bit(&features));
+  EXPECT_FALSE(kConfigs[TEST_c].get_bit(&features));
 }
 
 TEST_F(LinuxFeatureAggregatorTest, FromHwcapsNone) {


### PR DESCRIPTION
To avoid modifying the Get*FeaturesEnumValue() function, one can use a setter function. 