### PR TITLE
Differentiate between different Lake uarch

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -116,7 +116,9 @@ typedef enum {
   INTEL_ATOM_GMT,  // GOLDMONT
   INTEL_KBL,       // KABY LAKE
   INTEL_CFL,       // COFFEE LAKE
+  INTEL_WHL,       // WHISKEY LAKE
   INTEL_CNL,       // CANNON LAKE
+  INTEL_ICL,       // ICE LAKE
   AMD_HAMMER,      // K8
   AMD_K10,         // K10
   AMD_BOBCAT,      // K14

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -689,10 +689,27 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x06, 0x5E):
         // https://en.wikipedia.org/wiki/Skylake_(microarchitecture)
         return INTEL_SKL;
+      case CPUID(0x06, 0x66):
+        // https://en.wikipedia.org/wiki/Cannon_Lake_(microarchitecture)
+        return INTEL_CNL;
+      case CPUID(0x06, 0x7E):
+        // https://en.wikipedia.org/wiki/Ice_Lake_(microprocessor)
+        return INTEL_ICL;
       case CPUID(0x06, 0x8E):
+        switch (info->stepping) {
+          case 9:  return INTEL_KBL;  // https://en.wikipedia.org/wiki/Kaby_Lake
+          case 10: return INTEL_CFL;  // https://en.wikipedia.org/wiki/Coffee_Lake
+          case 11: return INTEL_WHL;  // https://en.wikipedia.org/wiki/Whiskey_Lake_(microarchitecture)
+          default: return X86_UNKNOWN;
+        }
       case CPUID(0x06, 0x9E):
-        // https://en.wikipedia.org/wiki/Kaby_Lake
-        return INTEL_KBL;
+        if (info->stepping > 9) {
+          // https://en.wikipedia.org/wiki/Coffee_Lake
+          return INTEL_CFL;
+        } else {
+          // https://en.wikipedia.org/wiki/Kaby_Lake
+          return INTEL_KBL;
+        }
       default:
         return X86_UNKNOWN;
     }


### PR DESCRIPTION
Issue #97 is caused by the fact that the Family and Model numbers of Kaby Lake and Coffee Lake CPUs are the same. The only way I could see to work around that is by using their Stepping values to differentiate them. 

According to https://en.wikichip.org/wiki/intel/microarchitectures/kaby_lake and https://en.wikichip.org/wiki/intel/microarchitectures/coffee_lake, these are:

Kaby Lake Stepping values: 9,
Coffee Lake Stepping values: 10, 11, 12, 13

I'm quite new to Git and C so please give me any necessary feedback to improve this commit.
Fixes #97 

Edit:
I've also included code changes to properly detect Cannon Lake, Ice Lake and Whiskey Lake processors.