### PR TITLE
Add INTEL_WHL and INTEL_ICL to uarch get name function

### DIFF
--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -1009,8 +1009,12 @@ const char* GetX86MicroarchitectureName(X86Microarchitecture uarch) {
       return "INTEL_KBL";
     case INTEL_CFL:
       return "INTEL_CFL";
+    case INTEL_WHL:
+      return "INTEL_WHL";
     case INTEL_CNL:
       return "INTEL_CNL";
+    case INTEL_ICL:
+      return "INTEL_ICL";
     case AMD_HAMMER:
       return "AMD_HAMMER";
     case AMD_K10:


### PR DESCRIPTION
Follow up from #99. Forgot to add INTEL_WHL and INTEL_ICL to the GetX86MicroarchitectureName function.