### PR TITLE
[NFC] Use Designated Initializers

### DIFF
--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -131,344 +131,859 @@ static int IsVendor(const Leaf leaf, const char* const name) {
 
 static const CacheLevelInfo kEmptyCacheLevelInfo;
 
-static CacheLevelInfo MakeX86CacheLevelInfo(int level, CacheType cache_type,
-                                            int cache_size, int ways,
-                                            int line_size, int entries,
-                                            int partitioning) {
-  CacheLevelInfo info;
-  info.level = level;
-  info.cache_type = cache_type;
-  info.cache_size = cache_size;
-  info.ways = ways;
-  info.line_size = line_size;
-  info.tlb_entries = entries;
-  info.partitioning = partitioning;
-  return info;
-}
-
 static CacheLevelInfo GetCacheLevelInfo(const uint32_t reg) {
   const int UNDEF = -1;
   const int KiB = 1024;
   const int MiB = 1024 * KiB;
   switch (reg) {
     case 0x01:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 4,
-                                   UNDEF, 32, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 32,
+                              .partitioning = 0};
     case 0x02:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * MiB, 0xFF,
-                                   UNDEF, 2, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * MiB,
+                              .ways = 0xFF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 2,
+                              .partitioning = 0};
     case 0x03:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 4,
-                                   UNDEF, 64, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 64,
+                              .partitioning = 0};
     case 0x04:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * MiB, 4,
-                                   UNDEF, 8, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * MiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 8,
+                              .partitioning = 0};
     case 0x05:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * MiB, 4,
-                                   UNDEF, 32, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * MiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 32,
+                              .partitioning = 0};
     case 0x06:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_INSTRUCTION, 8 * KiB, 4,
-                                   32, UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_INSTRUCTION,
+                              .cache_size = 8 * KiB,
+                              .ways = 4,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x08:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_INSTRUCTION, 16 * KiB,
-                                   4, 32, UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_INSTRUCTION,
+                              .cache_size = 16 * KiB,
+                              .ways = 4,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x09:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_INSTRUCTION, 32 * KiB,
-                                   4, 64, UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_INSTRUCTION,
+                              .cache_size = 32 * KiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x0A:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_DATA, 8 * KiB, 2, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 8 * KiB,
+                              .ways = 2,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x0B:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * MiB, 4,
-                                   UNDEF, 4, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * MiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 4,
+                              .partitioning = 0};
     case 0x0C:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_DATA, 16 * KiB, 4, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 16 * KiB,
+                              .ways = 4,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x0D:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_DATA, 16 * KiB, 4, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 16 * KiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x0E:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_DATA, 24 * KiB, 6, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 24 * KiB,
+                              .ways = 6,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x1D:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 128 * KiB, 2, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 128 * KiB,
+                              .ways = 2,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x21:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 256 * KiB, 8, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 256 * KiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x22:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 512 * KiB, 4, 64,
-                                   UNDEF, 2);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 512 * KiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 2};
     case 0x23:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 1 * MiB, 8, 64,
-                                   UNDEF, 2);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 1 * MiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 2};
     case 0x24:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 1 * MiB, 16, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 1 * MiB,
+                              .ways = 16,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x25:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 2 * MiB, 8, 64,
-                                   UNDEF, 2);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 2 * MiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 2};
     case 0x29:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 4 * MiB, 8, 64,
-                                   UNDEF, 2);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 4 * MiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 2};
     case 0x2C:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_DATA, 32 * KiB, 8, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 32 * KiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x30:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_INSTRUCTION, 32 * KiB,
-                                   8, 64, UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_INSTRUCTION,
+                              .cache_size = 32 * KiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x40:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_DATA, UNDEF, UNDEF,
-                                   UNDEF, UNDEF, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = UNDEF,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x41:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 128 * KiB, 4, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 128 * KiB,
+                              .ways = 4,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x42:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 256 * KiB, 4, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 256 * KiB,
+                              .ways = 4,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x43:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 512 * KiB, 4, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 512 * KiB,
+                              .ways = 4,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x44:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 1 * MiB, 4, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 1 * MiB,
+                              .ways = 4,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x45:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 2 * MiB, 4, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 2 * MiB,
+                              .ways = 4,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x46:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 4 * MiB, 4, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 4 * MiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x47:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 8 * MiB, 8, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 8 * MiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x48:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 3 * MiB, 12, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 3 * MiB,
+                              .ways = 12,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x49:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 4 * MiB, 16, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 4 * MiB,
+                              .ways = 16,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case (0x49 | (1 << 8)):
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 4 * MiB, 16, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 4 * MiB,
+                              .ways = 16,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x4A:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 6 * MiB, 12, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 6 * MiB,
+                              .ways = 12,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x4B:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 8 * MiB, 16, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 8 * MiB,
+                              .ways = 16,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x4C:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 12 * MiB, 12, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 12 * MiB,
+                              .ways = 12,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x4D:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 16 * MiB, 16, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 16 * MiB,
+                              .ways = 16,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x4E:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 6 * MiB, 24, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 6 * MiB,
+                              .ways = 24,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x4F:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, UNDEF,
-                                   UNDEF, 32, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 32,
+                              .partitioning = 0};
     case 0x50:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, UNDEF,
-                                   UNDEF, 64, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 64,
+                              .partitioning = 0};
     case 0x51:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, UNDEF,
-                                   UNDEF, 128, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 128,
+                              .partitioning = 0};
     case 0x52:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, UNDEF,
-                                   UNDEF, 256, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 256,
+                              .partitioning = 0};
     case 0x55:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 2 * MiB, 0xFF,
-                                   UNDEF, 7, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 2 * MiB,
+                              .ways = 0xFF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 7,
+                              .partitioning = 0};
     case 0x56:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * MiB, 4,
-                                   UNDEF, 16, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * MiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 16,
+                              .partitioning = 0};
     case 0x57:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 4,
-                                   UNDEF, 16, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 16,
+                              .partitioning = 0};
     case 0x59:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 0xFF,
-                                   UNDEF, 16, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 0xFF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 16,
+                              .partitioning = 0};
     case 0x5A:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 2 * MiB, 4,
-                                   UNDEF, 32, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 2 * MiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 32,
+                              .partitioning = 0};
     case 0x5B:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, UNDEF,
-                                   UNDEF, 64, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 64,
+                              .partitioning = 0};
     case 0x5C:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, UNDEF,
-                                   UNDEF, 128, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 128,
+                              .partitioning = 0};
     case 0x5D:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4, UNDEF,
-                                   UNDEF, 256, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 256,
+                              .partitioning = 0};
     case 0x60:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_DATA, 16 * KiB, 8, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 16 * KiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x61:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 0xFF,
-                                   UNDEF, 48, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 0xFF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 48,
+                              .partitioning = 0};
     case 0x63:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 2 * MiB, 4,
-                                   UNDEF, 4, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 2 * MiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 4,
+                              .partitioning = 0};
     case 0x66:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_DATA, 8 * KiB, 4, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 8 * KiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x67:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_DATA, 16 * KiB, 4, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 16 * KiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x68:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_DATA, 32 * KiB, 4, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 32 * KiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x70:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_INSTRUCTION, 12 * KiB,
-                                   8, UNDEF, UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_INSTRUCTION,
+                              .cache_size = 12 * KiB,
+                              .ways = 8,
+                              .line_size = UNDEF,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x71:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_INSTRUCTION, 16 * KiB,
-                                   8, UNDEF, UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_INSTRUCTION,
+                              .cache_size = 16 * KiB,
+                              .ways = 8,
+                              .line_size = UNDEF,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x72:
-      return MakeX86CacheLevelInfo(1, CPU_FEATURE_CACHE_INSTRUCTION, 32 * KiB,
-                                   8, UNDEF, UNDEF, 0);
+      return (CacheLevelInfo){.level = 1,
+                              .cache_type = CPU_FEATURE_CACHE_INSTRUCTION,
+                              .cache_size = 32 * KiB,
+                              .ways = 8,
+                              .line_size = UNDEF,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x76:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 2 * MiB, 0xFF,
-                                   UNDEF, 8, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 2 * MiB,
+                              .ways = 0xFF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 8,
+                              .partitioning = 0};
     case 0x78:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 1 * MiB, 4, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 1 * MiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x79:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 128 * KiB, 8, 64,
-                                   UNDEF, 2);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 128 * KiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 2};
     case 0x7A:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 256 * KiB, 8, 64,
-                                   UNDEF, 2);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 256 * KiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 2};
     case 0x7B:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 512 * KiB, 8, 64,
-                                   UNDEF, 2);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 512 * KiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 2};
     case 0x7C:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 1 * MiB, 8, 64,
-                                   UNDEF, 2);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 1 * MiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 2};
     case 0x7D:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 2 * MiB, 8, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 2 * MiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x7F:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 512 * KiB, 2, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 512 * KiB,
+                              .ways = 2,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x80:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 512 * KiB, 8, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 512 * KiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x82:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 256 * KiB, 8, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 256 * KiB,
+                              .ways = 8,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x83:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 512 * KiB, 8, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 512 * KiB,
+                              .ways = 8,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x84:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 1 * MiB, 8, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 1 * MiB,
+                              .ways = 8,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x85:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 2 * MiB, 8, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 2 * MiB,
+                              .ways = 8,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x86:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 512 * KiB, 4, 32,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 512 * KiB,
+                              .ways = 4,
+                              .line_size = 32,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0x87:
-      return MakeX86CacheLevelInfo(2, CPU_FEATURE_CACHE_DATA, 1 * MiB, 8, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 2,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 1 * MiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xA0:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_DTLB, 4 * KiB, 0xFF,
-                                   UNDEF, 32, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_DTLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 0xFF,
+                              .line_size = UNDEF,
+                              .tlb_entries = 32,
+                              .partitioning = 0};
     case 0xB0:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 4,
-                                   UNDEF, 128, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 128,
+                              .partitioning = 0};
     case 0xB1:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 2 * MiB, 4,
-                                   UNDEF, 8, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 2 * MiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 8,
+                              .partitioning = 0};
     case 0xB2:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 4,
-                                   UNDEF, 64, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 64,
+                              .partitioning = 0};
     case 0xB3:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 4,
-                                   UNDEF, 128, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 128,
+                              .partitioning = 0};
     case 0xB4:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 4,
-                                   UNDEF, 256, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 256,
+                              .partitioning = 0};
     case 0xB5:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 8,
-                                   UNDEF, 64, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 8,
+                              .line_size = UNDEF,
+                              .tlb_entries = 64,
+                              .partitioning = 0};
     case 0xB6:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 8,
-                                   UNDEF, 128, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 8,
+                              .line_size = UNDEF,
+                              .tlb_entries = 128,
+                              .partitioning = 0};
     case 0xBA:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 4,
-                                   UNDEF, 64, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 64,
+                              .partitioning = 0};
     case 0xC0:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_TLB, 4 * KiB, 4,
-                                   UNDEF, 8, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_TLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 8,
+                              .partitioning = 0};
     case 0xC1:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_STLB, 4 * KiB, 8,
-                                   UNDEF, 1024, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_STLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 8,
+                              .line_size = UNDEF,
+                              .tlb_entries = 1024,
+                              .partitioning = 0};
     case 0xC2:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_DTLB, 4 * KiB, 4,
-                                   UNDEF, 16, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_DTLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 16,
+                              .partitioning = 0};
     case 0xC3:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_STLB, 4 * KiB, 6,
-                                   UNDEF, 1536, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_STLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 6,
+                              .line_size = UNDEF,
+                              .tlb_entries = 1536,
+                              .partitioning = 0};
     case 0xCA:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_STLB, 4 * KiB, 4,
-                                   UNDEF, 512, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_STLB,
+                              .cache_size = 4 * KiB,
+                              .ways = 4,
+                              .line_size = UNDEF,
+                              .tlb_entries = 512,
+                              .partitioning = 0};
     case 0xD0:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 512 * KiB, 4, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 512 * KiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xD1:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 1 * MiB, 4, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 1 * MiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xD2:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 2 * MiB, 4, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 2 * MiB,
+                              .ways = 4,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xD6:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 1 * MiB, 8, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 1 * MiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xD7:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 2 * MiB, 8, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 2 * MiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xD8:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 4 * MiB, 8, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 4 * MiB,
+                              .ways = 8,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xDC:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 1 * 1536 * KiB,
-                                   12, 64, UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 1 * 1536 * KiB,
+                              .ways = 12,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xDD:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 3 * MiB, 12, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 3 * MiB,
+                              .ways = 12,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xDE:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 6 * MiB, 12, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 6 * MiB,
+                              .ways = 12,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xE2:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 2 * MiB, 16, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 2 * MiB,
+                              .ways = 16,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xE3:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 4 * MiB, 16, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 4 * MiB,
+                              .ways = 16,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xE4:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 8 * MiB, 16, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 8 * MiB,
+                              .ways = 16,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xEA:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 12 * MiB, 24, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 12 * MiB,
+                              .ways = 24,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xEB:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 18 * MiB, 24, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 18 * MiB,
+                              .ways = 24,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xEC:
-      return MakeX86CacheLevelInfo(3, CPU_FEATURE_CACHE_DATA, 24 * MiB, 24, 64,
-                                   UNDEF, 0);
+      return (CacheLevelInfo){.level = 3,
+                              .cache_type = CPU_FEATURE_CACHE_DATA,
+                              .cache_size = 24 * MiB,
+                              .ways = 24,
+                              .line_size = 64,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xF0:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_PREFETCH, 64 * KiB,
-                                   UNDEF, UNDEF, UNDEF, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_PREFETCH,
+                              .cache_size = 64 * KiB,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xF1:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_PREFETCH, 128 * KiB,
-                                   UNDEF, UNDEF, UNDEF, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_PREFETCH,
+                              .cache_size = 128 * KiB,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     case 0xFF:
-      return MakeX86CacheLevelInfo(UNDEF, CPU_FEATURE_CACHE_NULL, UNDEF, UNDEF,
-                                   UNDEF, UNDEF, 0);
+      return (CacheLevelInfo){.level = UNDEF,
+                              .cache_type = CPU_FEATURE_CACHE_NULL,
+                              .cache_size = UNDEF,
+                              .ways = UNDEF,
+                              .line_size = UNDEF,
+                              .tlb_entries = UNDEF,
+                              .partitioning = 0};
     default:
       return kEmptyCacheLevelInfo;
   }
@@ -511,10 +1026,15 @@ static void ParseLeaf4(const int max_cpuid_leaf, CacheInfo* info) {
     int line_size = ExtractBitRange(leaf.ebx, 11, 0) + 1;
     int partitioning = ExtractBitRange(leaf.ebx, 21, 12) + 1;
     int ways = ExtractBitRange(leaf.ebx, 31, 22) + 1;
-    int entries = leaf.ecx + 1;
-    int cache_size = (ways * partitioning * line_size * (entries));
-    info->levels[cache_id] = MakeX86CacheLevelInfo(
-        level, cache_type, cache_size, ways, line_size, entries, partitioning);
+    int tlb_entries = leaf.ecx + 1;
+    int cache_size = (ways * partitioning * line_size * (tlb_entries));
+    info->levels[cache_id] = (CacheLevelInfo){.level = level,
+                                              .cache_type = cache_type,
+                                              .cache_size = cache_size,
+                                              .ways = ways,
+                                              .line_size = line_size,
+                                              .tlb_entries = tlb_entries,
+                                              .partitioning = partitioning};
     info->size++;
   }
 }


### PR DESCRIPTION
This is a mechanical change. This is to prevent error in argument ordering.
@fexolm Can you provide me with the source of the data you used for traceability?