### PR TITLE
CMake: Add missing alias for cpu_feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set_property(TARGET cpu_features PROPERTY POSITION_INDEPENDENT_CODE ${BUILD_PIC}
 target_include_directories(cpu_features
   PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpu_features>
 )
+add_library(CpuFeature::cpu_features ALIAS cpu_features)
 
 #
 # program : list_cpu_features


### PR DESCRIPTION
For customers using add_subdirectory() approach

related to #106