### PR TITLE
add future Intel microarchitectures

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -121,6 +121,7 @@ typedef enum {
   INTEL_WHL,       // WHISKEY LAKE
   INTEL_CNL,       // CANNON LAKE
   INTEL_ICL,       // ICE LAKE
+  INTEL_SPR,       // SAPPHIRE RAPIDS
   AMD_HAMMER,      // K8
   AMD_K10,         // K10
   AMD_BOBCAT,      // K14

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -1,4 +1,5 @@
 // Copyright 2017 Google Inc.
+// Copyright 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -121,6 +121,7 @@ typedef enum {
   INTEL_WHL,       // WHISKEY LAKE
   INTEL_CNL,       // CANNON LAKE
   INTEL_ICL,       // ICE LAKE
+  INTEL_TGL,       // TIGER LAKE
   INTEL_SPR,       // SAPPHIRE RAPIDS
   AMD_HAMMER,      // K8
   AMD_K10,         // K10

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -1241,9 +1241,14 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x06, 0x66):
         // https://en.wikipedia.org/wiki/Cannon_Lake_(microarchitecture)
         return INTEL_CNL;
-      case CPUID(0x06, 0x7E):
+      case CPUID(0x06, 0x7E): // client
+      case CPUID(0x06, 0x6A): // server
+      case CPUID(0x06, 0x6C): // server
         // https://en.wikipedia.org/wiki/Ice_Lake_(microprocessor)
         return INTEL_ICL;
+      case CPUID(0x06, 0x8F):
+        // https://en.wikipedia.org/wiki/Sapphire_Rapids
+        return INTEL_SPR;
       case CPUID(0x06, 0x8E):
         switch (info->stepping) {
           case 9:  return INTEL_KBL;  // https://en.wikipedia.org/wiki/Kaby_Lake

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -1,4 +1,5 @@
 // Copyright 2017 Google Inc.
+// Copyright 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -1241,11 +1241,17 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x06, 0x66):
         // https://en.wikipedia.org/wiki/Cannon_Lake_(microarchitecture)
         return INTEL_CNL;
+      case CPUID(0x06, 0x7D): // client
       case CPUID(0x06, 0x7E): // client
+      case CPUID(0x06, 0x9D): // NNP-I
       case CPUID(0x06, 0x6A): // server
       case CPUID(0x06, 0x6C): // server
         // https://en.wikipedia.org/wiki/Ice_Lake_(microprocessor)
         return INTEL_ICL;
+      case CPUID(0x06, 0x8C):
+      case CPUID(0x06, 0x8D):
+        // https://en.wikipedia.org/wiki/Tiger_Lake_(microarchitecture)
+        return INTEL_TGL;
       case CPUID(0x06, 0x8F):
         // https://en.wikipedia.org/wiki/Sapphire_Rapids
         return INTEL_SPR;
@@ -1577,6 +1583,10 @@ const char* GetX86MicroarchitectureName(X86Microarchitecture uarch) {
       return "INTEL_CNL";
     case INTEL_ICL:
       return "INTEL_ICL";
+    case INTEL_TGL:
+      return "INTEL_TGL";
+    case INTEL_SPR:
+      return "INTEL_SPR";
     case AMD_HAMMER:
       return "AMD_HAMMER";
     case AMD_K10:


### PR DESCRIPTION
This change adds new Ice Lake variants, Tiger Lake and Sapphire Rapids.  CPUID info is documented and has been tested.