### PR TITLE
detect future Intel AVX/AMX features

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -68,7 +68,7 @@ typedef struct {
   int avx512bitalg : 1;
   int avx512vpopcntdq : 1;
   int avx512_4vnniw : 1;
-  int avx512_4vbmi2 : 1;
+  int avx512_4fmaps : 1;
   int avx512_bf16 : 1;
   int avx512_vp2intersect : 1;
 
@@ -189,7 +189,7 @@ typedef enum {
   X86_AVX512BITALG,
   X86_AVX512VPOPCNTDQ,
   X86_AVX512_4VNNIW,
-  X86_AVX512_4VBMI2,
+  X86_AVX512_4FMAPS,
   X86_AVX512_BF16,
   X86_AVX512_VP2INTERSECT,
   X86_PCLMULQDQ,

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -69,6 +69,8 @@ typedef struct {
   int avx512vpopcntdq : 1;
   int avx512_4vnniw : 1;
   int avx512_4vbmi2 : 1;
+  int avx512_bf16 : 1;
+  int avx512_vp2intersect : 1;
 
   int pclmulqdq : 1;
   int smx : 1;
@@ -188,6 +190,8 @@ typedef enum {
   X86_AVX512VPOPCNTDQ,
   X86_AVX512_4VNNIW,
   X86_AVX512_4VBMI2,
+  X86_AVX512_BF16,
+  X86_AVX512_VP2INTERSECT,
   X86_PCLMULQDQ,
   X86_SMX,
   X86_SGX,

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -121,6 +121,7 @@ typedef enum {
   INTEL_WHL,       // WHISKEY LAKE
   INTEL_CNL,       // CANNON LAKE
   INTEL_ICL,       // ICE LAKE
+  INTEL_SPR,       // SAPPHIRE RAPIDS
   AMD_HAMMER,      // K8
   AMD_K10,         // K10
   AMD_BOBCAT,      // K14

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -72,6 +72,10 @@ typedef struct {
   int avx512_bf16 : 1;
   int avx512_vp2intersect : 1;
 
+  int amx_bf16 : 1;
+  int amx_tile : 1;
+  int amx_int8 : 1;
+
   int pclmulqdq : 1;
   int smx : 1;
   int sgx : 1;
@@ -192,6 +196,9 @@ typedef enum {
   X86_AVX512_4FMAPS,
   X86_AVX512_BF16,
   X86_AVX512_VP2INTERSECT,
+  X86_AMX_BF16,
+  X86_AMX_TILE,
+  X86_AMX_INT8,
   X86_PCLMULQDQ,
   X86_SMX,
   X86_SGX,

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -1,4 +1,5 @@
 // Copyright 2017 Google Inc.
+// Copyright 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -121,6 +121,7 @@ typedef enum {
   INTEL_WHL,       // WHISKEY LAKE
   INTEL_CNL,       // CANNON LAKE
   INTEL_ICL,       // ICE LAKE
+  INTEL_TGL,       // TIGER LAKE
   INTEL_SPR,       // SAPPHIRE RAPIDS
   AMD_HAMMER,      // K8
   AMD_K10,         // K10

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -91,6 +91,8 @@ static Leaf SafeCpuId(uint32_t max_cpuid_leaf, uint32_t leaf_id) {
 #define MASK_MASKREG 0x20
 #define MASK_ZMM0_15 0x40
 #define MASK_ZMM16_31 0x80
+#define MASK_XTILECFG 0x20000
+#define MASK_XTILEDATA 0x40000
 
 static bool HasMask(uint32_t value, uint32_t mask) {
   return (value & mask) == mask;
@@ -113,6 +115,13 @@ static bool HasYmmOsXSave(uint32_t xcr0_eax) {
 static bool HasZmmOsXSave(uint32_t xcr0_eax) {
   return HasMask(xcr0_eax, MASK_XMM | MASK_YMM | MASK_MASKREG | MASK_ZMM0_15 |
                                MASK_ZMM16_31);
+}
+
+// Checks that operating system saves and restores AMX/TMUL state during context
+// switches.
+static bool HasTmmOsXSave(uint32_t xcr0_eax) {
+  return HasMask(xcr0_eax, MASK_XMM | MASK_YMM | MASK_MASKREG | MASK_ZMM0_15 |
+                               MASK_ZMM16_31 | MASK_XTILECFG | MASK_XTILEDATA);
 }
 
 static void SetVendor(const Leaf leaf, char* const vendor) {
@@ -1045,6 +1054,7 @@ typedef struct {
   bool have_sse;
   bool have_avx;
   bool have_avx512;
+  bool have_amx;
 } OsSupport;
 
 // Reference https://en.wikipedia.org/wiki/CPUID.
@@ -1059,6 +1069,7 @@ static void ParseCpuId(const uint32_t max_cpuid_leaf, X86Info* info, OsSupport* 
   os_support->have_sse = HasXmmOsXSave(xcr0_eax);
   os_support->have_avx = HasYmmOsXSave(xcr0_eax);
   os_support->have_avx512 = HasZmmOsXSave(xcr0_eax);
+  os_support->have_amx = HasTmmOsXSave(xcr0_eax);
 
   const uint32_t family = ExtractBitRange(leaf_1.eax, 11, 8);
   const uint32_t extended_family = ExtractBitRange(leaf_1.eax, 27, 20);
@@ -1132,6 +1143,12 @@ static void ParseCpuId(const uint32_t max_cpuid_leaf, X86Info* info, OsSupport* 
     features->avx512_4fmaps = IsBitSet(leaf_7.edx, 3);
     features->avx512_bf16 = IsBitSet(leaf_7_1.eax, 5);
     features->avx512_vp2intersect = IsBitSet(leaf_7.edx, 8);
+  }
+
+  if (os_support->have_amx) {
+    features->amx_bf16 = IsBitSet(leaf_7.edx, 22);
+    features->amx_tile = IsBitSet(leaf_7.edx, 24);
+    features->amx_int8 = IsBitSet(leaf_7.edx, 25);
   }
 }
 
@@ -1412,6 +1429,12 @@ int GetX86FeaturesEnumValue(const X86Features* features,
       return features->avx512_bf16;
     case X86_AVX512_VP2INTERSECT:
       return features->avx512_vp2intersect;
+    case X86_AMX_BF16:
+      return features->amx_bf16;
+    case X86_AMX_TILE:
+      return features->amx_tile;
+    case X86_AMX_INT8:
+      return features->amx_int8;
     case X86_PCLMULQDQ:
       return features->pclmulqdq;
     case X86_SMX:
@@ -1530,6 +1553,12 @@ const char* GetX86FeaturesEnumName(X86FeaturesEnum value) {
       return "avx512_bf16";
     case X86_AVX512_VP2INTERSECT:
       return "avx512_vp2intersect";
+    case X86_AMX_BF16:
+      return "amx_bf16";
+    case X86_AMX_TILE:
+      return "amx_tile";
+    case X86_AMX_INT8:
+      return "amx_int8";
     case X86_PCLMULQDQ:
       return "pclmulqdq";
     case X86_SMX:

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -1129,7 +1129,7 @@ static void ParseCpuId(const uint32_t max_cpuid_leaf, X86Info* info, OsSupport* 
     features->avx512bitalg = IsBitSet(leaf_7.ecx, 12);
     features->avx512vpopcntdq = IsBitSet(leaf_7.ecx, 14);
     features->avx512_4vnniw = IsBitSet(leaf_7.edx, 2);
-    features->avx512_4vbmi2 = IsBitSet(leaf_7.edx, 3);
+    features->avx512_4fmaps = IsBitSet(leaf_7.edx, 3);
     features->avx512_bf16 = IsBitSet(leaf_7_1.eax, 5);
     features->avx512_vp2intersect = IsBitSet(leaf_7.edx, 8);
   }
@@ -1406,8 +1406,8 @@ int GetX86FeaturesEnumValue(const X86Features* features,
       return features->avx512vpopcntdq;
     case X86_AVX512_4VNNIW:
       return features->avx512_4vnniw;
-    case X86_AVX512_4VBMI2:
-      return features->avx512_4vbmi2;
+    case X86_AVX512_4FMAPS:
+      return features->avx512_4fmaps;
     case X86_AVX512_BF16:
       return features->avx512_bf16;
     case X86_AVX512_VP2INTERSECT:
@@ -1524,8 +1524,8 @@ const char* GetX86FeaturesEnumName(X86FeaturesEnum value) {
       return "avx512vpopcntdq";
     case X86_AVX512_4VNNIW:
       return "avx512_4vnniw";
-    case X86_AVX512_4VBMI2:
-      return "avx512_4vbmi2";
+    case X86_AVX512_4FMAPS:
+      return "avx512_4fmaps";
     case X86_AVX512_BF16:
       return "avx512_bf16";
     case X86_AVX512_VP2INTERSECT:

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -1241,9 +1241,14 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x06, 0x66):
         // https://en.wikipedia.org/wiki/Cannon_Lake_(microarchitecture)
         return INTEL_CNL;
-      case CPUID(0x06, 0x7E):
+      case CPUID(0x06, 0x7E): // client
+      case CPUID(0x06, 0x6A): // server
+      case CPUID(0x06, 0x6C): // server
         // https://en.wikipedia.org/wiki/Ice_Lake_(microprocessor)
         return INTEL_ICL;
+      case CPUID(0x06, 0x8F):
+        // https://en.wikipedia.org/wiki/Sapphire_Rapids
+        return INTEL_SPR;
       case CPUID(0x06, 0x8E):
         switch (info->stepping) {
           case 9:  return INTEL_KBL;  // https://en.wikipedia.org/wiki/Kaby_Lake

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -1051,6 +1051,7 @@ typedef struct {
 static void ParseCpuId(const uint32_t max_cpuid_leaf, X86Info* info, OsSupport* os_support) {
   const Leaf leaf_1 = SafeCpuId(max_cpuid_leaf, 1);
   const Leaf leaf_7 = SafeCpuId(max_cpuid_leaf, 7);
+  const Leaf leaf_7_1 = SafeCpuIdEx(max_cpuid_leaf, 7, 1);
 
   const bool have_xsave = IsBitSet(leaf_1.ecx, 26);
   const bool have_osxsave = IsBitSet(leaf_1.ecx, 27);
@@ -1129,6 +1130,8 @@ static void ParseCpuId(const uint32_t max_cpuid_leaf, X86Info* info, OsSupport* 
     features->avx512vpopcntdq = IsBitSet(leaf_7.ecx, 14);
     features->avx512_4vnniw = IsBitSet(leaf_7.edx, 2);
     features->avx512_4vbmi2 = IsBitSet(leaf_7.edx, 3);
+    features->avx512_bf16 = IsBitSet(leaf_7_1.eax, 5);
+    features->avx512_vp2intersect = IsBitSet(leaf_7.edx, 8);
   }
 }
 
@@ -1405,6 +1408,10 @@ int GetX86FeaturesEnumValue(const X86Features* features,
       return features->avx512_4vnniw;
     case X86_AVX512_4VBMI2:
       return features->avx512_4vbmi2;
+    case X86_AVX512_BF16:
+      return features->avx512_bf16;
+    case X86_AVX512_VP2INTERSECT:
+      return features->avx512_vp2intersect;
     case X86_PCLMULQDQ:
       return features->pclmulqdq;
     case X86_SMX:
@@ -1519,6 +1526,10 @@ const char* GetX86FeaturesEnumName(X86FeaturesEnum value) {
       return "avx512_4vnniw";
     case X86_AVX512_4VBMI2:
       return "avx512_4vbmi2";
+    case X86_AVX512_BF16:
+      return "avx512_bf16";
+    case X86_AVX512_VP2INTERSECT:
+      return "avx512_vp2intersect";
     case X86_PCLMULQDQ:
       return "pclmulqdq";
     case X86_SMX:

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -1,4 +1,5 @@
 // Copyright 2017 Google Inc.
+// Copyright 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -1241,11 +1241,17 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x06, 0x66):
         // https://en.wikipedia.org/wiki/Cannon_Lake_(microarchitecture)
         return INTEL_CNL;
+      case CPUID(0x06, 0x7D): // client
       case CPUID(0x06, 0x7E): // client
+      case CPUID(0x06, 0x9D): // NNP-I
       case CPUID(0x06, 0x6A): // server
       case CPUID(0x06, 0x6C): // server
         // https://en.wikipedia.org/wiki/Ice_Lake_(microprocessor)
         return INTEL_ICL;
+      case CPUID(0x06, 0x8C):
+      case CPUID(0x06, 0x8D):
+        // https://en.wikipedia.org/wiki/Tiger_Lake_(microarchitecture)
+        return INTEL_TGL;
       case CPUID(0x06, 0x8F):
         // https://en.wikipedia.org/wiki/Sapphire_Rapids
         return INTEL_SPR;
@@ -1577,6 +1583,10 @@ const char* GetX86MicroarchitectureName(X86Microarchitecture uarch) {
       return "INTEL_CNL";
     case INTEL_ICL:
       return "INTEL_ICL";
+    case INTEL_TGL:
+      return "INTEL_TGL";
+    case INTEL_SPR:
+      return "INTEL_SPR";
     case AMD_HAMMER:
       return "AMD_HAMMER";
     case AMD_K10:

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -88,7 +88,7 @@ TEST(CpuidX86Test, SandyBridge) {
   EXPECT_FALSE(features.avx512bitalg);
   EXPECT_FALSE(features.avx512vpopcntdq);
   EXPECT_FALSE(features.avx512_4vnniw);
-  EXPECT_FALSE(features.avx512_4vbmi2);
+  EXPECT_FALSE(features.avx512_4fmaps);
   // All old cpu features should be set.
   EXPECT_TRUE(features.aes);
   EXPECT_TRUE(features.ssse3);


### PR DESCRIPTION
This change:
- detects AVX-512 BF16, introduced in Cooper Lake
- detects AVX-512 VP2INTERSECT, introduced in Tiger Lake
- detects AMX, introduced in Sapphire Rapids

This is documented and has been tested.