### PR TITLE
Fix ndk-compat include directory (Fix #106)

### DIFF
--- a/ndk_compat/CMakeLists.txt
+++ b/ndk_compat/CMakeLists.txt
@@ -15,6 +15,7 @@ set (NDK_COMPAT_SRCS
 add_cpu_features_headers_and_sources(NDK_COMPAT_SRCS NDK_COMPAT_SRCS)
 add_library(ndk_compat ${NDK_COMPAT_HDRS} ${NDK_COMPAT_SRCS})
 setup_include_and_definitions(ndk_compat)
+target_include_directories(ndk_compat PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_link_libraries(ndk_compat PUBLIC ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(ndk_compat PROPERTIES PUBLIC_HEADER "${NDK_COMPAT_HDRS}")
 


### PR DESCRIPTION
Should fix the issue.

We are using this macro: https://github.com/google/cpu_features/blob/c186ec53072de068cfd5fac46704d0dd760f0b61/CMakeLists.txt#L42-L50
here:
https://github.com/google/cpu_features/blob/c186ec53072de068cfd5fac46704d0dd760f0b61/ndk_compat/CMakeLists.txt#L17

Unfortunately `cpu-features.h` is in ndk-compat directory not in `root/include` directory...'