### PR TITLE
Fix clang-format not being installed (fixes build error on #153)

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -2,4 +2,4 @@
 # ref: https://hub.docker.com/_/alpine
 FROM alpine:edge
 # Install system build dependencies
-RUN apk add --no-cache git clang
+RUN apk add --no-cache git clang clang-extra-tools


### PR DESCRIPTION
clang-format was moved to the `clang-extra-tools` package on current alpine edge