### PR TITLE
github/workflows: fix install clang-format to use clang-extra-tools pkg

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -2,4 +2,4 @@
 # ref: https://hub.docker.com/_/alpine
 FROM alpine:edge
 # Install system build dependencies
-RUN apk add --no-cache git clang
+RUN apk add --no-cache git clang-extra-tools


### PR DESCRIPTION
addressed https://github.com/google/cpu_features/pull/153#issuecomment-814456058, fix install `clang-format` binary to use `clang-extra-tools` package.