### PR TITLE
Detect Intel's Multi-Precision Add-Carry Instruction Extensions

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -89,6 +89,7 @@ typedef struct {
 
   int dca : 1;
   int ss : 1;
+  int adx : 1;
   // Make sure to update X86FeaturesEnum below if you add a field here.
 } X86Features;
 
@@ -214,6 +215,7 @@ typedef enum {
   X86_RDRND,
   X86_DCA,
   X86_SS,
+  X86_ADX,
   X86_LAST_,
 } X86FeaturesEnum;
 

--- a/src/cpuinfo_x86.c
+++ b/src/cpuinfo_x86.c
@@ -88,7 +88,8 @@
   FEATURE(X86_MOVBE, movbe, "movbe", 0, 0)                                     \
   FEATURE(X86_RDRND, rdrnd, "rdrnd", 0, 0)                                     \
   FEATURE(X86_DCA, dca, "dca", 0, 0)                                           \
-  FEATURE(X86_SS, ss, "ss", 0, 0)
+  FEATURE(X86_SS, ss, "ss", 0, 0)                                              \
+  FEATURE(X86_ADX, adx, "adx", 0, 0)
 #define DEFINE_TABLE_FEATURE_TYPE X86Features
 #define DEFINE_TABLE_DONT_GENERATE_HWCAPS
 #include "define_tables.h"
@@ -1314,6 +1315,7 @@ static void ParseCpuId(const uint32_t max_cpuid_leaf,
   features->sha = IsBitSet(leaf_7.ebx, 29);
   features->vaes = IsBitSet(leaf_7.ecx, 9);
   features->vpclmulqdq = IsBitSet(leaf_7.ecx, 10);
+  features->adx = IsBitSet(leaf_7.ebx, 19);
 
   if (os_support.have_sse_via_os) {
     DetectSseViaOs(features);

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -148,6 +148,7 @@ TEST_F(CpuidX86Test, SandyBridge) {
   EXPECT_TRUE(features.popcnt);
   EXPECT_FALSE(features.movbe);
   EXPECT_FALSE(features.rdrnd);
+  EXPECT_FALSE(features.adx);
 }
 
 const int KiB = 1024;


### PR DESCRIPTION
Intel has added ADOX, ADCX instructions to Broadwell microarchitecture. They are quite useful in cryptographic applications where two addition chains are being performed in parallel. 

Both Intel and AMD (Ryzen) support those instructions.

https://en.wikipedia.org/wiki/CPUID
