### PR TITLE
fix: Return default value from ‘GetCacheTypeString’

### DIFF
--- a/include/cpu_features_macros.h
+++ b/include/cpu_features_macros.h
@@ -213,4 +213,17 @@
 #endif  //  defined(__mips_msa)
 #endif  //  defined(CPU_FEATURES_ARCH_MIPS)
 
+////////////////////////////////////////////////////////////////////////////////
+// Utils
+////////////////////////////////////////////////////////////////////////////////
+
+// Communicates to the compiler that the block is unreachable
+#if defined(CPU_FEATURES_COMPILER_CLANG) || defined(CPU_FEATURES_COMPILER_GCC)
+#define UNREACHABLE() __builtin_unreachable()
+#elif defined(CPU_FEATURES_COMPILER_MSC)
+#define UNREACHABLE() __assume(0)
+#else
+#define UNREACHABLE()
+#endif
+
 #endif  // CPU_FEATURES_INCLUDE_CPU_FEATURES_MACROS_H_

--- a/src/utils/list_cpu_features.c
+++ b/src/utils/list_cpu_features.c
@@ -340,6 +340,7 @@ static Node* GetCacheTypeString(CacheType cache_type) {
     case CPU_FEATURE_CACHE_PREFETCH:
       return CreateConstantString("prefetch");
   }
+  UNREACHABLE();
 }
 
 static void AddCacheInfo(Node* root, const CacheInfo* cache_info) {


### PR DESCRIPTION
The build fails with following message when -Werror
and -Werror=return-type are enabled.

In function ‘GetCacheTypeString’:
	error: control reaches end of non-void function [-Werror=return-type]

Simple fix is to return 0 from that function. The
return value is then checked by an assert in the
AddMapEntry. The assert will only work in debug mode,
but that seems to be enough.