### PR TITLE
Add cache level limits to AddCacheInfo

### DIFF
--- a/src/utils/list_cpu_features.c
+++ b/src/utils/list_cpu_features.c
@@ -344,9 +344,11 @@ static Node* GetCacheTypeString(CacheType cache_type) {
 }
 
 static void AddCacheInfo(Node* root, const CacheInfo* cache_info) {
+  const int UNDEF = -1;
   Node* array = CreateArray();
   for (int i = 0; i < cache_info->size; ++i) {
     CacheLevelInfo info = cache_info->levels[i];
+    if (info.level == UNDEF || info.level > CPU_FEATURES_MAX_CACHE_LEVEL) continue;
     Node* map = CreateMap();
     AddMapEntry(map, "level", CreateInt(info.level));
     AddMapEntry(map, "cache_type", GetCacheTypeString(info.cache_type));


### PR DESCRIPTION
`list_cpu_features` segfaults in at least some cases after 641e24e.  I am experiencing on Linux (Comet Lake) and FreeBSD (Kaby Lake).  PR resolves by limiting parsing in AddCacheInfo to the range of possible cache levels.