### PR TITLE
ci: Migrate FreeBSD to macos-10.15 virtual env

### DIFF
--- a/.github/workflows/x86_freebsd.yml
+++ b/.github/workflows/x86_freebsd.yml
@@ -11,7 +11,7 @@ jobs:
   # Only MacOS hosted runner provides virtualisation with vagrant/virtualbox installed.
   # see: https://github.com/actions/virtual-environments/tree/main/images/macos
   freebsd:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - name: vagrant version


### PR DESCRIPTION
note: In preparation to https://github.com/actions/virtual-environments/issues/4060
which will drop Vagrant/VirtualBox

ref: https://github.com/actions/virtual-environments/pull/4010