### PR TITLE
cmake: Fix test enabling for ndk_compat

### DIFF
--- a/ndk_compat/CMakeLists.txt
+++ b/ndk_compat/CMakeLists.txt
@@ -54,7 +54,7 @@ install(
 #
 # program : NDK compat test program
 #
-if(ENABLE_TESTING)
+if(BUILD_TESTING)
   add_executable(ndk-compat-test ndk-compat-test.c)
   target_link_libraries(ndk-compat-test PRIVATE ndk_compat)
 endif()


### PR DESCRIPTION
We must use **`BUILD_TESTING`** and not ~~`ENABLE_TESTING`~~
note: I think it's a mistake with `enable_testing()`

src: https://cmake.org/cmake/help/latest/command/enable_testing.html#enable-testing