### PR TITLE
API change: embed `brand_string` in GetX86Info()

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -103,7 +103,8 @@ typedef struct {
   int family;
   int model;
   int stepping;
-  char vendor[13];  // 0 terminated string
+  char vendor[13];        // 0 terminated string
+  char brand_string[49];  // 0 terminated string
 } X86Info;
 
 // Calls cpuid and returns an initialized X86info.
@@ -156,11 +157,6 @@ typedef enum {
 // Returns the underlying microarchitecture by looking at X86Info's vendor,
 // family and model.
 X86Microarchitecture GetX86Microarchitecture(const X86Info* info);
-
-// Calls cpuid and fills the brand_string.
-// - brand_string *must* be of size 49 (beware of array decaying).
-// - brand_string will be zero terminated.
-void FillX86BrandString(char brand_string[49]);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Introspection functions

--- a/src/utils/list_cpu_features.c
+++ b/src/utils/list_cpu_features.c
@@ -366,9 +366,8 @@ static Node* CreateTree() {
   char brand_string[49];
   const X86Info info = GetX86Info();
   const CacheInfo cache_info = GetX86CacheInfo();
-  FillX86BrandString(brand_string);
   AddMapEntry(root, "arch", CreateString("x86"));
-  AddMapEntry(root, "brand", CreateString(brand_string));
+  AddMapEntry(root, "brand", CreateString(info.brand_string));
   AddMapEntry(root, "family", CreateInt(info.family));
   AddMapEntry(root, "model", CreateInt(info.model));
   AddMapEntry(root, "stepping", CreateInt(info.stepping));

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -206,9 +206,8 @@ TEST_F(CpuidX86Test, Branding) {
       {{0x80000003, 0}, Leaf{0x37692029, 0x3035362D, 0x43205530, 0x40205550}},
       {{0x80000004, 0}, Leaf{0x352E3220, 0x7A484730, 0x00000000, 0x00000000}},
   });
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz");
+  const auto info = GetX86Info();
+  EXPECT_STREQ(info.brand_string, "Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz");
 }
 
 TEST_F(CpuidX86Test, KabyLakeCache) {
@@ -412,14 +411,12 @@ TEST_F(CpuidX86Test, AMD_K15_EXCAVATOR_STONEY_RIDGE) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.brand_string,
+               "AMD A9-9410 RADEON R5, 5 COMPUTE CORES 2C+3G   ");
   EXPECT_EQ(info.family, 0x15);
   EXPECT_EQ(info.model, 0x70);
   EXPECT_EQ(GetX86Microarchitecture(&info),
             X86Microarchitecture::AMD_EXCAVATOR);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "AMD A9-9410 RADEON R5, 5 COMPUTE CORES 2C+3G   ");
 }
 
 // http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0600F20_K15_AbuDhabi_CPUID0.txt
@@ -437,14 +434,12 @@ TEST_F(CpuidX86Test, AMD_K15_PILEDRIVER_ABU_DHABI) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.brand_string,
+               "AMD Opteron(tm) Processor 6376                 ");
   EXPECT_EQ(info.family, 0x15);
   EXPECT_EQ(info.model, 0x02);
   EXPECT_EQ(GetX86Microarchitecture(&info),
             X86Microarchitecture::AMD_PILEDRIVER);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "AMD Opteron(tm) Processor 6376                 ");
 }
 
 // http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0600F20_K15_AbuDhabi_CPUID0.txt
@@ -510,14 +505,12 @@ TEST_F(CpuidX86Test, AMD_K15_BULLDOZER_INTERLAGOS) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.brand_string,
+               "AMD Opteron(TM) Processor 6238                 ");
   EXPECT_EQ(info.family, 0x15);
   EXPECT_EQ(info.model, 0x01);
   EXPECT_EQ(GetX86Microarchitecture(&info),
             X86Microarchitecture::AMD_BULLDOZER);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "AMD Opteron(TM) Processor 6238                 ");
 }
 
 // http://users.atw.hu/instlatx64/AuthenticAMD0630F81_K15_Godavari_CPUID.txt
@@ -536,15 +529,13 @@ TEST_F(CpuidX86Test, AMD_K15_STREAMROLLER_GODAVARI) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.brand_string,
+               "AMD A8-7670K Radeon R7, 10 Compute Cores 4C+6G ");
   EXPECT_EQ(info.family, 0x15);
   EXPECT_EQ(info.model, 0x38);
   EXPECT_EQ(info.stepping, 0x01);
   EXPECT_EQ(GetX86Microarchitecture(&info),
             X86Microarchitecture::AMD_STREAMROLLER);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "AMD A8-7670K Radeon R7, 10 Compute Cores 4C+6G ");
 }
 
 // http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0700F01_K16_Kabini_CPUID.txt
@@ -562,13 +553,11 @@ TEST_F(CpuidX86Test, AMD_K16_JAGUAR_KABINI) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.brand_string,
+               "AMD A4-5000 APU with Radeon(TM) HD Graphics    ");
   EXPECT_EQ(info.family, 0x16);
   EXPECT_EQ(info.model, 0x00);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_JAGUAR);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "AMD A4-5000 APU with Radeon(TM) HD Graphics    ");
 }
 
 // http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0730F01_K16_Beema_CPUID2.txt
@@ -586,13 +575,11 @@ TEST_F(CpuidX86Test, AMD_K16_PUMA_BEEMA) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.brand_string,
+               "AMD A6-6310 APU with AMD Radeon R4 Graphics    ");
   EXPECT_EQ(info.family, 0x16);
   EXPECT_EQ(info.model, 0x30);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_PUMA);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "AMD A6-6310 APU with AMD Radeon R4 Graphics    ");
 }
 
 // http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0820F01_K17_Dali_CPUID.txt
@@ -610,13 +597,11 @@ TEST_F(CpuidX86Test, AMD_K17_ZEN_DALI) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.brand_string,
+               "AMD 3020e with Radeon Graphics                 ");
   EXPECT_EQ(info.family, 0x17);
   EXPECT_EQ(info.model, 0x20);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_ZEN);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "AMD 3020e with Radeon Graphics                 ");
 }
 
 // http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0800F82_K17_ZenP_CPUID.txt
@@ -634,13 +619,11 @@ TEST_F(CpuidX86Test, AMD_K17_ZEN_PLUS_PINNACLE_RIDGE) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.brand_string,
+               "AMD Ryzen 7 2700X Eight-Core Processor         ");
   EXPECT_EQ(info.family, 0x17);
   EXPECT_EQ(info.model, 0x08);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_ZEN_PLUS);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "AMD Ryzen 7 2700X Eight-Core Processor         ");
 }
 
 // http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0840F70_K17_CPUID.txt
@@ -658,13 +641,10 @@ TEST_F(CpuidX86Test, AMD_K17_ZEN2_XBOX_SERIES_X) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.brand_string, "AMD 4700S 8-Core Processor Desktop Kit");
   EXPECT_EQ(info.family, 0x17);
   EXPECT_EQ(info.model, 0x47);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_ZEN2);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "AMD 4700S 8-Core Processor Desktop Kit");
 }
 
 // http://users.atw.hu/instlatx64/HygonGenuine/HygonGenuine0900F02_Hygon_CPUID3.txt
@@ -682,13 +662,11 @@ TEST_F(CpuidX86Test, AMD_K18_ZEN_DHYANA) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "HygonGenuine");
+  EXPECT_STREQ(info.brand_string,
+               "Hygon C86 3185  8-core Processor               ");
   EXPECT_EQ(info.family, 0x18);
   EXPECT_EQ(info.model, 0x00);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_ZEN);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "Hygon C86 3185  8-core Processor               ");
 }
 
 // http://users.atw.hu/instlatx64/HygonGenuine/HygonGenuine0900F02_Hygon_CPUID.txt
@@ -754,13 +732,11 @@ TEST_F(CpuidX86Test, AMD_K19_ZEN3_VERMEER) {
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.brand_string,
+               "AMD Ryzen 9 5900X 12-Core Processor            ");
   EXPECT_EQ(info.family, 0x19);
   EXPECT_EQ(info.model, 0x21);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_ZEN3);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "AMD Ryzen 9 5900X 12-Core Processor            ");
 }
 
 // https://github.com/InstLatx64/InstLatx64/blob/master/GenuineIntel/GenuineIntel00106A1_Nehalem_CPUID.txt
@@ -824,14 +800,12 @@ flags           : fpu mmx sse sse2 sse3 ssse3 sse4_1 sse4_2
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.brand_string,
+               "Genuine Intel(R) CPU           @ 0000 @ 1.87GHz");
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x1A);
   EXPECT_EQ(info.stepping, 0x02);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_NHM);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "Genuine Intel(R) CPU           @ 0000 @ 1.87GHz");
 
   EXPECT_TRUE(info.features.sse);
   EXPECT_TRUE(info.features.sse2);
@@ -905,15 +879,13 @@ flags           : fpu mmx sse sse2 sse3 ssse3 sse4_1 sse4_2
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.brand_string,
+               "      Intel(R) Celeron(R) CPU  J1900  @ 1.99GHz");
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x37);
   EXPECT_EQ(info.stepping, 0x03);
   EXPECT_EQ(GetX86Microarchitecture(&info),
             X86Microarchitecture::INTEL_ATOM_SMT);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "      Intel(R) Celeron(R) CPU  J1900  @ 1.99GHz");
 
   EXPECT_TRUE(info.features.sse);
   EXPECT_TRUE(info.features.sse2);
@@ -1011,14 +983,11 @@ flags           : fpu mmx sse
   const auto info = GetX86Info();
 
   EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.brand_string, "");
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x07);
   EXPECT_EQ(info.stepping, 0x03);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::X86_UNKNOWN);
-
-  char brand_string[49];
-  FillX86BrandString(brand_string);
-  EXPECT_STREQ(brand_string, "");
 
   EXPECT_TRUE(info.features.mmx);
   EXPECT_TRUE(info.features.sse);


### PR DESCRIPTION
This is an API change.
It reduces the chance that user passes an invalid buffer to `FillBrandString`