### PR TITLE
Fix the build for M1 MacBooks

### DIFF
--- a/src/impl_aarch64.c
+++ b/src/impl_aarch64.c
@@ -15,7 +15,7 @@
 #include "cpu_features_macros.h"
 
 #ifdef CPU_FEATURES_ARCH_AARCH64
-#if defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID)
+#if defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID) || defined(CPU_FEATURES_OS_MACOS)
 
 #include "cpuinfo_aarch64.h"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 ##------------------------------------------------------------------------------
 ## cpuinfo_aarch64_test
 if(PROCESSOR_IS_AARCH64)
-  add_executable(cpuinfo_aarch64_test cpuinfo_aarch64_test.cc ../src/impl_aarch64_linux_or_android.c)
+  add_executable(cpuinfo_aarch64_test cpuinfo_aarch64_test.cc ../src/impl_aarch64.c)
   target_link_libraries(cpuinfo_aarch64_test all_libraries)
   add_test(NAME cpuinfo_aarch64_test COMMAND cpuinfo_aarch64_test)
 endif()


### PR DESCRIPTION
It turns out, MACOS is a perfectly fine OS to support aarch64 (through its name
arm64.)

The only thing missing was the appropriate check in impl_aarch64, plus renaming
the file to match that it's really for any OS that has the CPU.

jwatte@Jons-MBP build % make test
Running tests...
Test project /Users/jwatte/cpu_features/build
    Start 1: bit_utils_test
1/4 Test #1: bit_utils_test ...................   Passed    0.06 sec
    Start 2: string_view_test
2/4 Test #2: string_view_test .................   Passed    0.04 sec
    Start 3: stack_line_reader_test
3/4 Test #3: stack_line_reader_test ...........   Passed    0.04 sec
    Start 4: cpuinfo_aarch64_test
4/4 Test #4: cpuinfo_aarch64_test .............   Passed    0.12 sec