### PR TITLE
replace sse3 detection with pni when reading /proc/cpuinfo

### DIFF
--- a/src/impl_x86_linux_or_android.c
+++ b/src/impl_x86_linux_or_android.c
@@ -44,7 +44,7 @@ static void DetectFeaturesFromOs(X86Info* info, X86Features* features) {
       if (!CpuFeatures_StringView_IsEquals(key, str("flags"))) continue;
       features->sse = CpuFeatures_StringView_HasWord(value, "sse", ' ');
       features->sse2 = CpuFeatures_StringView_HasWord(value, "sse2", ' ');
-      features->sse3 = CpuFeatures_StringView_HasWord(value, "sse3", ' ');
+      features->sse3 = CpuFeatures_StringView_HasWord(value, "pni", ' ');
       features->ssse3 = CpuFeatures_StringView_HasWord(value, "ssse3", ' ');
       features->sse4_1 = CpuFeatures_StringView_HasWord(value, "sse4_1", ' ');
       features->sse4_2 = CpuFeatures_StringView_HasWord(value, "sse4_2", ' ');

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -812,7 +812,7 @@ real memory  = 2147418112 (2047 MB)
 #elif defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID)
   auto& fs = GetEmptyFilesystem();
   fs.CreateFile("/proc/cpuinfo", R"(processor       :
-flags           : fpu mmx sse sse2 sse3 ssse3 sse4_1 sse4_2
+flags           : fpu mmx sse sse2 pni ssse3 sse4_1 sse4_2
 )");
 #endif
   cpu().SetLeaves({
@@ -896,7 +896,7 @@ real memory  = 2147418112 (2047 MB)
 #elif defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID)
   auto& fs = GetEmptyFilesystem();
   fs.CreateFile("/proc/cpuinfo", R"(
-flags           : fpu mmx sse sse2 sse3 ssse3 sse4_1 sse4_2
+flags           : fpu mmx sse sse2 pni ssse3 sse4_1 sse4_2
 )");
 #endif
   cpu().SetLeaves({


### PR DESCRIPTION
See issue https://github.com/google/cpu_features/issues/224
Thanks.