### PR TITLE
ci: Add bazel jobs

### DIFF
--- a/.github/workflows/amd64_bazel_linux.yml
+++ b/.github/workflows/amd64_bazel_linux.yml
@@ -1,0 +1,26 @@
+name: amd64 Bazel Linux
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # min hours day(month) month day(week)
+    - cron: '0 0 7,22 * *'
+
+jobs:
+  # Building using the github runner environement directly.
+  bazel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install Bazel
+        run: |
+          curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
+          sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
+          echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+          sudo apt-get update
+          sudo apt-get install bazel
+          bazel --version
+      - name: Test
+        run: bazel test -s --verbose_failures //...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,21 +1,17 @@
 workspace(name = "com_google_cpufeatures")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-http_archive(
+git_repository(
     name = "com_google_googletest",
-    sha256 = "1cff5915c9dfbf8241d811e95230833c4f34a6d56b7b8c960f4c828f60429a38",
-    strip_prefix = "googletest-c9461a9b55ba954df0489bab6420eb297bed846b",
-    urls = ["https://github.com/google/googletest/archive/c9461a9b55ba954df0489bab6420eb297bed846b.zip"],
+    tag = "release-1.11.0",
+    remote = "https://github.com/google/googletest.git",
 )
 
-http_archive(
+git_repository(
     name = "bazel_skylib",
-    sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-    ],
+    tag = "1.2.0",
+    remote = "https://github.com/bazelbuild/bazel-skylib.git",
 )
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")


### PR DESCRIPTION
* [optional] Use `git_repository()` to retrieve dependencies
* Add amd64 Linux Bazel based build jobs.