### PR TITLE
Update AArch64 features to Linux 5.17.

### DIFF
--- a/include/cpuinfo_aarch64.h
+++ b/include/cpuinfo_aarch64.h
@@ -72,6 +72,9 @@ typedef struct {
   int rng : 1;         // True random number generator support.
   int bti : 1;         // Branch target identification.
   int mte : 1;         // Memory tagging extension.
+  int ecv : 1;         // Enhanced counter virtualization.
+  int afp : 1;         // Alternate floating-point behaviour.
+  int rpres : 1;       // 12-bit reciprocal (square root) estimate precision.
 
   // Make sure to update Aarch64FeaturesEnum below if you add a field here.
 } Aarch64Features;
@@ -141,6 +144,9 @@ typedef enum {
   AARCH64_RNG,
   AARCH64_BTI,
   AARCH64_MTE,
+  AARCH64_ECV,
+  AARCH64_AFP,
+  AARCH64_RPRES,
   AARCH64_LAST_,
 } Aarch64FeaturesEnum;
 

--- a/include/internal/hwcaps.h
+++ b/include/internal/hwcaps.h
@@ -80,6 +80,9 @@ CPU_FEATURES_START_CPP_NAMESPACE
 #define AARCH64_HWCAP2_RNG (1UL << 16)
 #define AARCH64_HWCAP2_BTI (1UL << 17)
 #define AARCH64_HWCAP2_MTE (1UL << 18)
+#define AARCH64_HWCAP2_ECV (1UL << 19)
+#define AARCH64_HWCAP2_AFP (1UL << 20)
+#define AARCH64_HWCAP2_RPRES (1UL << 21)
 
 // http://elixir.free-electrons.com/linux/latest/source/arch/arm/include/uapi/asm/hwcap.h
 #define ARM_HWCAP_SWP (1UL << 0)

--- a/src/impl_aarch64_linux_or_android.c
+++ b/src/impl_aarch64_linux_or_android.c
@@ -74,7 +74,10 @@
   LINE(AARCH64_DGH, dgh, "dgh", 0, AARCH64_HWCAP2_DGH)                     \
   LINE(AARCH64_RNG, rng, "rng", 0, AARCH64_HWCAP2_RNG)                     \
   LINE(AARCH64_BTI, bti, "bti", 0, AARCH64_HWCAP2_BTI)                     \
-  LINE(AARCH64_MTE, mte, "mte", 0, AARCH64_HWCAP2_MTE)
+  LINE(AARCH64_MTE, mte, "mte", 0, AARCH64_HWCAP2_MTE)                     \
+  LINE(AARCH64_ECV, ecv, "ecv", 0, AARCH64_HWCAP2_ECV)                     \
+  LINE(AARCH64_AFP, afp, "afp", 0, AARCH64_HWCAP2_AFP)                     \
+  LINE(AARCH64_RPRES, rpres, "rpres", 0, AARCH64_HWCAP2_RPRES)
 #define INTROSPECTION_PREFIX Aarch64
 #define INTROSPECTION_ENUM_PREFIX AARCH64
 #include "define_introspection_and_hwcaps.inl"

--- a/test/cpuinfo_aarch64_test.cc
+++ b/test/cpuinfo_aarch64_test.cc
@@ -168,6 +168,9 @@ CPU revision    : 3)");
   EXPECT_FALSE(info.features.rng);
   EXPECT_FALSE(info.features.bti);
   EXPECT_FALSE(info.features.mte);
+  EXPECT_FALSE(info.features.ecv);
+  EXPECT_FALSE(info.features.afp);
+  EXPECT_FALSE(info.features.rpres);
 }
 
 }  // namespace


### PR DESCRIPTION
Adds three new features: ecv, afp and rpres.