### PR TITLE
Add AMD ZEN 4 uarch and update detection

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -167,6 +167,7 @@ typedef enum {
   AMD_ZEN_PLUS,        // K17 ZEN+
   AMD_ZEN2,            // K17 ZEN 2
   AMD_ZEN3,            // K19 ZEN 3
+  AMD_ZEN4,            // K19 ZEN 4
   X86_MICROARCHITECTURE_LAST_,
 } X86Microarchitecture;
 

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -706,13 +706,19 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x17, 0x98):
         // https://en.wikichip.org/wiki/amd/microarchitectures/zen_2
         return AMD_ZEN2;
+      case CPUID(0x19, 0x00):
       case CPUID(0x19, 0x01):
+      case CPUID(0x19, 0x08):
       case CPUID(0x19, 0x21):
       case CPUID(0x19, 0x30):
       case CPUID(0x19, 0x40):
+      case CPUID(0x19, 0x44):
       case CPUID(0x19, 0x50):
         // https://en.wikichip.org/wiki/amd/microarchitectures/zen_3
         return AMD_ZEN3;
+      case CPUID(0x19, 0x10):
+        // https://en.wikichip.org/wiki/amd/microarchitectures/zen_4
+        return AMD_ZEN4;
       default:
         return X86_UNKNOWN;
     }
@@ -720,6 +726,7 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
   if (IsVendorByX86Info(info, CPU_FEATURES_VENDOR_HYGON_GENUINE)) {
     switch (CPUID(info->family, info->model)) {
       case CPUID(0x18, 0x00):
+      case CPUID(0x18, 0x01):
         return AMD_ZEN;
     }
   }
@@ -1797,7 +1804,8 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(AMD_ZEN)                     \
   LINE(AMD_ZEN_PLUS)                \
   LINE(AMD_ZEN2)                    \
-  LINE(AMD_ZEN3)
+  LINE(AMD_ZEN3)                    \
+  LINE(AMD_ZEN4)
 
 const char* GetX86MicroarchitectureName(X86Microarchitecture value) {
 #define LINE(ENUM) [ENUM] = STRINGIZE(ENUM),

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -784,6 +784,48 @@ TEST_F(CpuidX86Test, AMD_K19_ZEN3_VERMEER) {
   EXPECT_STREQ(brand_string, "AMD Ryzen 9 5900X 12-Core Processor            ");
 }
 
+// http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0A40F41_K19_Rembrandt_03_CPUID.txt
+TEST_F(CpuidX86Test, AMD_K19_ZEN3) {
+  cpu().SetLeaves({
+      {{0x00000000, 0}, Leaf{0x00000010, 0x68747541, 0x444D4163, 0x69746E65}},
+      {{0x00000001, 0}, Leaf{0x00A40F41, 0x00100800, 0x7EF8320B, 0x178BFBFF}},
+      {{0x80000000, 0}, Leaf{0x80000023, 0x68747541, 0x444D4163, 0x69746E65}},
+      {{0x80000001, 0}, Leaf{0x00A40F41, 0x50000000, 0x75C237FF, 0x2FD3FBFF}},
+      {{0x80000002, 0}, Leaf{0x20444D41, 0x657A7952, 0x2039206E, 0x30303936}},
+      {{0x80000003, 0}, Leaf{0x77205848, 0x20687469, 0x65646152, 0x47206E6F}},
+      {{0x80000004, 0}, Leaf{0x68706172, 0x20736369, 0x20202020, 0x00202020}},
+  });
+  const auto info = GetX86Info();
+
+  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_EQ(info.family, 0x19);
+  EXPECT_EQ(info.model, 0x44);
+  EXPECT_STREQ(info.brand_string,
+               "AMD Ryzen 9 6900HX with Radeon Graphics        ");
+  EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_ZEN3);
+}
+
+// http://users.atw.hu/instlatx64/HygonGenuine/HygonGenuine0900F11_Hygon_01_CPUID.txt
+TEST_F(CpuidX86Test, AMD_K18_ZEN_DHYANA_OCTAL_CORE_C86_3250) {
+  cpu().SetLeaves({
+      {{0x00000000, 0}, Leaf{0x0000000D, 0x6F677948, 0x656E6975, 0x6E65476E}},
+      {{0x00000001, 0}, Leaf{0x00900F11, 0x00100800, 0x76D8320B, 0x178BFBFF}},
+      {{0x80000000, 0}, Leaf{0x8000001F, 0x6F677948, 0x656E6975, 0x6E65476E}},
+      {{0x80000001, 0}, Leaf{0x00900F11, 0x60000000, 0x35C233FF, 0x2FD3FBFF}},
+      {{0x80000002, 0}, Leaf{0x6F677948, 0x3843206E, 0x32332036, 0x20203035}},
+      {{0x80000003, 0}, Leaf{0x6F632D38, 0x50206572, 0x65636F72, 0x726F7373}},
+      {{0x80000004, 0}, Leaf{0x20202020, 0x20202020, 0x20202020, 0x00202020}},
+  });
+  const auto info = GetX86Info();
+
+  EXPECT_EQ(info.model, 0x01);
+  EXPECT_EQ(info.family, 0x18);
+  EXPECT_STREQ(info.vendor, "HygonGenuine");
+  EXPECT_STREQ(info.brand_string,
+               "Hygon C86 3250  8-core Processor               ");
+  EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_ZEN);
+}
+
 // https://github.com/InstLatx64/InstLatx64/blob/master/GenuineIntel/GenuineIntel00106A1_Nehalem_CPUID.txt
 TEST_F(CpuidX86Test, Nehalem) {
   // Pre AVX cpus don't have xsave


### PR DESCRIPTION
In this PR I added uarch detection to Zen 4, and updated Zen 3, Hygon


Zen 4: https://en.wikichip.org/wiki/amd/cpuid

Zen 3: 
* Threadripper 5900 "Chagall" (sWRX8), see https://en.wikichip.org/wiki/amd/cpuid (Family: 25, Model: 0x08)
* Engineering Sample ([SP3](https://en.wikichip.org/wiki/amd/packages/sp3)), see https://en.wikichip.org/wiki/amd/cpuid (Family: 25, Model: 0x00)
* OctalCore AMD Ryzen 9 6900HX  [Rembrandt Cpuid Dump](http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0A40F41_K19_Rembrandt_03_CPUID.txt) (Family:  0x19, Model: 0x44)

OctalCore Hygon C86 3250: [Cpuid Dump](http://users.atw.hu/instlatx64/HygonGenuine/HygonGenuine0900F11_Hygon_01_CPUID.txt) (Family:  0x18, Model: 0x01)