### PR TITLE
test enum macro consistency

### DIFF
--- a/test/cpuinfo_aarch64_test.cc
+++ b/test/cpuinfo_aarch64_test.cc
@@ -23,6 +23,18 @@ namespace {
 
 void DisableHardwareCapabilities() { SetHardwareCapabilities(0, 0); }
 
+TEST(CpuinfoAarch64Test, Aarch64FeaturesEnum) {
+   const char *last_name = GetAarch64FeaturesEnumName(AARCH64_LAST_);
+   EXPECT_STREQ(last_name, "unknown_feature");
+   for (int i = static_cast<int>(AARCH64_FP); i != static_cast<int>(AARCH64_LAST_); ++i) {
+      const auto feature = static_cast<Aarch64FeaturesEnum>(i);
+      const char *name = GetAarch64FeaturesEnumName(feature);
+      ASSERT_FALSE(name == nullptr);
+      EXPECT_STRNE(name, "");
+      EXPECT_STRNE(name, last_name);
+   }
+}
+
 TEST(CpuinfoAarch64Test, FromHardwareCap) {
   ResetHwcaps();
   SetHardwareCapabilities(AARCH64_HWCAP_FP | AARCH64_HWCAP_AES, 0);

--- a/test/cpuinfo_arm_test.cc
+++ b/test/cpuinfo_arm_test.cc
@@ -21,6 +21,18 @@
 namespace cpu_features {
 namespace {
 
+TEST(CpuinfoArmTest, ArmFeaturesEnum) {
+   const char *last_name = GetArmFeaturesEnumName(ARM_LAST_);
+   EXPECT_STREQ(last_name, "unknown_feature");
+   for (int i = static_cast<int>(ARM_SWP); i != static_cast<int>(ARM_LAST_); ++i) {
+      const auto feature = static_cast<ArmFeaturesEnum>(i);
+      const char *name = GetArmFeaturesEnumName(feature);
+      ASSERT_FALSE(name == nullptr);
+      EXPECT_STRNE(name, "");
+      EXPECT_STRNE(name, last_name);
+   }
+}
+
 TEST(CpuinfoArmTest, FromHardwareCap) {
   ResetHwcaps();
   SetHardwareCapabilities(ARM_HWCAP_NEON, ARM_HWCAP2_AES | ARM_HWCAP2_CRC32);

--- a/test/cpuinfo_mips_test.cc
+++ b/test/cpuinfo_mips_test.cc
@@ -24,6 +24,18 @@ namespace cpu_features {
 
 namespace {
 
+TEST(CpuinfoMipsTest, MipsFeaturesEnum) {
+   const char *last_name = GetMipsFeaturesEnumName(MIPS_LAST_);
+   EXPECT_STREQ(last_name, "unknown_feature");
+   for (int i = static_cast<int>(MIPS_MSA); i != static_cast<int>(MIPS_LAST_); ++i) {
+      const auto feature = static_cast<MipsFeaturesEnum>(i);
+      const char *name = GetMipsFeaturesEnumName(feature);
+      ASSERT_FALSE(name == nullptr);
+      EXPECT_STRNE(name, "");
+      EXPECT_STRNE(name, last_name);
+   }
+}
+
 TEST(CpuinfoMipsTest, FromHardwareCapBoth) {
   ResetHwcaps();
   SetHardwareCapabilities(MIPS_HWCAP_MSA | MIPS_HWCAP_R6, 0);

--- a/test/cpuinfo_ppc_test.cc
+++ b/test/cpuinfo_ppc_test.cc
@@ -22,6 +22,18 @@
 namespace cpu_features {
 namespace {
 
+TEST(CpustringsPPCTest, PPCFeaturesEnum) {
+   const char *last_name = GetPPCFeaturesEnumName(PPC_LAST_);
+   EXPECT_STREQ(last_name, "unknown_feature");
+   for (int i = static_cast<int>(PPC_32); i != static_cast<int>(PPC_LAST_); ++i) {
+      const auto feature = static_cast<PPCFeaturesEnum>(i);
+      const char *name = GetPPCFeaturesEnumName(feature);
+      ASSERT_FALSE(name == nullptr);
+      EXPECT_STRNE(name, "");
+      EXPECT_STRNE(name, last_name);
+   }
+}
+
 TEST(CpustringsPPCTest, FromHardwareCap) {
   ResetHwcaps();
   SetHardwareCapabilities(PPC_FEATURE_HAS_FPU | PPC_FEATURE_HAS_VSX,

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -118,6 +118,30 @@ class CpuidX86Test : public ::testing::Test {
   }
 };
 
+TEST_F(CpuidX86Test, X86MicroarchitectureEnum) {
+   const char *last_name = GetX86MicroarchitectureName(X86_MICROARCHITECTURE_LAST_);
+   EXPECT_STREQ(last_name, "unknown microarchitecture");
+   for (int i = static_cast<int>(X86_UNKNOWN); i != static_cast<int>(X86_MICROARCHITECTURE_LAST_); ++i) {
+      const auto micro = static_cast<X86Microarchitecture>(i);
+      const char *name = GetX86MicroarchitectureName(micro);
+      EXPECT_FALSE(name == nullptr);
+      EXPECT_STRNE(name, "");
+      EXPECT_STRNE(name, last_name);
+   }
+}
+
+TEST_F(CpuidX86Test, X86FeaturesEnum) {
+   const char *last_name = GetX86FeaturesEnumName(X86_LAST_);
+   EXPECT_STREQ(last_name, "unknown_feature");
+   for (int i = static_cast<int>(X86_FPU); i != static_cast<int>(X86_LAST_); ++i) {
+      const auto feature = static_cast<X86FeaturesEnum>(i);
+      const char *name = GetX86FeaturesEnumName(feature);
+      EXPECT_FALSE(name == nullptr);
+      EXPECT_STRNE(name, "");
+      EXPECT_STRNE(name, last_name);
+   }
+}
+
 TEST_F(CpuidX86Test, SandyBridge) {
   cpu().SetOsBackupsExtendedRegisters(true);
   cpu().SetLeaves({

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -124,7 +124,7 @@ TEST_F(CpuidX86Test, X86MicroarchitectureEnum) {
    for (int i = static_cast<int>(X86_UNKNOWN); i != static_cast<int>(X86_MICROARCHITECTURE_LAST_); ++i) {
       const auto micro = static_cast<X86Microarchitecture>(i);
       const char *name = GetX86MicroarchitectureName(micro);
-      EXPECT_FALSE(name == nullptr);
+      ASSERT_FALSE(name == nullptr);
       EXPECT_STRNE(name, "");
       EXPECT_STRNE(name, last_name);
    }
@@ -136,7 +136,7 @@ TEST_F(CpuidX86Test, X86FeaturesEnum) {
    for (int i = static_cast<int>(X86_FPU); i != static_cast<int>(X86_LAST_); ++i) {
       const auto feature = static_cast<X86FeaturesEnum>(i);
       const char *name = GetX86FeaturesEnumName(feature);
-      EXPECT_FALSE(name == nullptr);
+      ASSERT_FALSE(name == nullptr);
       EXPECT_STRNE(name, "");
       EXPECT_STRNE(name, last_name);
    }


### PR DESCRIPTION
allows to check for LINE( presense in x86 feature and microarch arrays