### PR TITLE
Added some missing amd uarch

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -157,7 +157,6 @@ typedef enum {
   AMD_K10,             // K10
   AMD_K11,             // K11
   AMD_K12,             // K12
-  AMD_LLANO,           // LLANO
   AMD_BOBCAT,          // K14 BOBCAT
   AMD_PILEDRIVER,      // K15 PILEDRIVER
   AMD_STREAMROLLER,    // K15 STREAMROLLER

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -157,6 +157,7 @@ typedef enum {
   AMD_K10,             // K10
   AMD_K11,             // K11
   AMD_K12,             // K12
+  AMD_LLANO,           // LLANO
   AMD_BOBCAT,          // K14 BOBCAT
   AMD_PILEDRIVER,      // K15 PILEDRIVER
   AMD_STREAMROLLER,    // K15 STREAMROLLER

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -156,7 +156,7 @@ typedef enum {
   AMD_HAMMER,          // K8  HAMMER
   AMD_K10,             // K10
   AMD_K11,             // K11
-  AMD_K12,             // K12
+  AMD_K12,             // K12 LLANO
   AMD_BOBCAT,          // K14 BOBCAT
   AMD_PILEDRIVER,      // K15 PILEDRIVER
   AMD_STREAMROLLER,    // K15 STREAMROLLER

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -1801,7 +1801,7 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(AMD_HAMMER)                  \
   LINE(AMD_K10)                     \
   LINE(AMD_K11)                     \
-  LINE(AMD_K12) /* K12 LLANO */     \
+  LINE(AMD_K12)                     \
   LINE(AMD_BOBCAT)                  \
   LINE(AMD_PILEDRIVER)              \
   LINE(AMD_STREAMROLLER)            \

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -667,6 +667,9 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x12, 0x01):
         // https://www.amd.com/system/files/TechDocs/44739_12h_Rev_Gd.pdf
         return AMD_K12;
+      case CPUID(0x12, 0x00):
+        // https://www.amd.com/system/files/TechDocs/44739_12h_Rev_Gd.pdf
+        return AMD_LLANO;
       case CPUID(0x14, 0x00):
       case CPUID(0x14, 0x01):
       case CPUID(0x14, 0x02):
@@ -676,6 +679,7 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
         // https://en.wikichip.org/wiki/amd/microarchitectures/bulldozer
         return AMD_BULLDOZER;
       case CPUID(0x15, 0x02):
+      case CPUID(0x15, 0x10):
       case CPUID(0x15, 0x11):
       case CPUID(0x15, 0x13):
         // https://en.wikichip.org/wiki/amd/microarchitectures/piledriver
@@ -695,11 +699,12 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
         return AMD_PUMA;
       case CPUID(0x17, 0x01):
       case CPUID(0x17, 0x11):
-      case CPUID(0x17, 0x18):
       case CPUID(0x17, 0x20):
+      case CPUID(0x18, 0x00):
         // https://en.wikichip.org/wiki/amd/microarchitectures/zen
         return AMD_ZEN;
       case CPUID(0x17, 0x08):
+      case CPUID(0x17, 0x18):
         // https://en.wikichip.org/wiki/amd/microarchitectures/zen%2B
         return AMD_ZEN_PLUS;
       case CPUID(0x17, 0x31):
@@ -1800,6 +1805,7 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(AMD_K10)                     \
   LINE(AMD_K11)                     \
   LINE(AMD_K12)                     \
+  LINE(AMD_LLANO)                   \
   LINE(AMD_BOBCAT)                  \
   LINE(AMD_PILEDRIVER)              \
   LINE(AMD_STREAMROLLER)            \

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -677,7 +677,6 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
         // https://en.wikichip.org/wiki/amd/microarchitectures/bulldozer
         return AMD_BULLDOZER;
       case CPUID(0x15, 0x02):
-      case CPUID(0x15, 0x10):
       case CPUID(0x15, 0x11):
       case CPUID(0x15, 0x13):
         // https://en.wikichip.org/wiki/amd/microarchitectures/piledriver

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -664,12 +664,10 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x11, 0x03):
         // http://developer.amd.com/wordpress/media/2012/10/41788.pdf
         return AMD_K11;
+      case CPUID(0x12, 0x00):
       case CPUID(0x12, 0x01):
         // https://www.amd.com/system/files/TechDocs/44739_12h_Rev_Gd.pdf
         return AMD_K12;
-      case CPUID(0x12, 0x00):
-        // https://www.amd.com/system/files/TechDocs/44739_12h_Rev_Gd.pdf
-        return AMD_LLANO;
       case CPUID(0x14, 0x00):
       case CPUID(0x14, 0x01):
       case CPUID(0x14, 0x02):
@@ -699,12 +697,11 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
         return AMD_PUMA;
       case CPUID(0x17, 0x01):
       case CPUID(0x17, 0x11):
+      case CPUID(0x17, 0x18):
       case CPUID(0x17, 0x20):
-      case CPUID(0x18, 0x00):
         // https://en.wikichip.org/wiki/amd/microarchitectures/zen
         return AMD_ZEN;
       case CPUID(0x17, 0x08):
-      case CPUID(0x17, 0x18):
         // https://en.wikichip.org/wiki/amd/microarchitectures/zen%2B
         return AMD_ZEN_PLUS;
       case CPUID(0x17, 0x31):
@@ -1804,8 +1801,7 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(AMD_HAMMER)                  \
   LINE(AMD_K10)                     \
   LINE(AMD_K11)                     \
-  LINE(AMD_K12)                     \
-  LINE(AMD_LLANO)                   \
+  LINE(AMD_K12) /* K12 LLANO */     \
   LINE(AMD_BOBCAT)                  \
   LINE(AMD_PILEDRIVER)              \
   LINE(AMD_STREAMROLLER)            \


### PR DESCRIPTION
According to https://en.wikichip.org/wiki/amd/cpuid I added detection of the following AMD uarch:

- ~Added family 0x18 model 0x00 to zen architecture~ 
- ~Moved family 0x17 model 0x18 from zen to zen plus architecture~
- ~Added family 0x15 model 0x10 to piledriver architecture~
- Created identifier for AMD_LLANO and added family 0x12 model 0x00 to it (Does it have to be merged with K12?)
   EDIT: merged with K12