### PR TITLE
Replace hardcoded values ​​to constants for X86 tests.

### DIFF
--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -150,7 +150,7 @@ TEST_F(CpuidX86Test, SandyBridge) {
       {{0x00000007, 0}, Leaf{0x00000000, 0x00000000, 0x00000000, 0x00000000}},
   });
   const auto info = GetX86Info();
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x02A);
   EXPECT_EQ(info.stepping, 0x06);
@@ -212,7 +212,7 @@ TEST_F(CpuidX86Test, SkyLake) {
       {{0x00000007, 0}, Leaf{0x00000000, 0x029C67AF, 0x00000000, 0x00000000}},
   });
   const auto info = GetX86Info();
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x04E);
   EXPECT_EQ(info.stepping, 0x03);
@@ -342,7 +342,7 @@ TEST_F(CpuidX86Test, AMD_K11_GRIFFIN) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x11);
   EXPECT_EQ(info.model, 0x03);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_K11);
@@ -358,7 +358,7 @@ TEST_F(CpuidX86Test, AMD_K12_LLANO) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x12);
   EXPECT_EQ(info.model, 0x01);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_K12);
@@ -374,7 +374,7 @@ TEST_F(CpuidX86Test, AMD_K14_BOBCAT_AMD0500F01) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x14);
   EXPECT_EQ(info.model, 0x00);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_BOBCAT);
@@ -398,7 +398,7 @@ TEST_F(CpuidX86Test, AMD_K14_BOBCAT_AMD0500F10) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x14);
   EXPECT_EQ(info.model, 0x01);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_BOBCAT);
@@ -414,7 +414,7 @@ TEST_F(CpuidX86Test, AMD_K14_BOBCAT_AMD0500F20) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x14);
   EXPECT_EQ(info.model, 0x02);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_BOBCAT);
@@ -434,7 +434,7 @@ TEST_F(CpuidX86Test, AMD_K15_EXCAVATOR_STONEY_RIDGE) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x15);
   EXPECT_EQ(info.model, 0x70);
   EXPECT_STREQ(info.brand_string,
@@ -457,7 +457,7 @@ TEST_F(CpuidX86Test, AMD_K15_PILEDRIVER_ABU_DHABI) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x15);
   EXPECT_EQ(info.model, 0x02);
   EXPECT_STREQ(info.brand_string,
@@ -530,7 +530,7 @@ TEST_F(CpuidX86Test, AMD_K15_BULLDOZER_INTERLAGOS) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x15);
   EXPECT_EQ(info.model, 0x01);
   EXPECT_STREQ(info.brand_string,
@@ -554,7 +554,7 @@ TEST_F(CpuidX86Test, AMD_K15_STREAMROLLER_GODAVARI) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x15);
   EXPECT_EQ(info.model, 0x38);
   EXPECT_EQ(info.stepping, 0x01);
@@ -575,7 +575,7 @@ TEST_F(CpuidX86Test, AMD_K15_BULLDOZER_ZAMBEZI_ABM) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x15);
   EXPECT_EQ(info.model, 0x01);
 
@@ -599,7 +599,7 @@ TEST_F(CpuidX86Test, AMD_K16_JAGUAR_KABINI) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x16);
   EXPECT_EQ(info.model, 0x00);
   EXPECT_STREQ(info.brand_string,
@@ -621,7 +621,7 @@ TEST_F(CpuidX86Test, AMD_K16_PUMA_BEEMA) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x16);
   EXPECT_EQ(info.model, 0x30);
   EXPECT_STREQ(info.brand_string,
@@ -643,7 +643,7 @@ TEST_F(CpuidX86Test, AMD_K17_ZEN_DALI) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x17);
   EXPECT_EQ(info.model, 0x20);
   EXPECT_STREQ(info.brand_string,
@@ -665,7 +665,7 @@ TEST_F(CpuidX86Test, AMD_K17_ZEN_PLUS_PINNACLE_RIDGE) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x17);
   EXPECT_EQ(info.model, 0x08);
   EXPECT_STREQ(info.brand_string,
@@ -687,7 +687,7 @@ TEST_F(CpuidX86Test, AMD_K17_ZEN2_XBOX_SERIES_X) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x17);
   EXPECT_EQ(info.model, 0x47);
   EXPECT_STREQ(info.brand_string, "AMD 4700S 8-Core Processor Desktop Kit");
@@ -708,7 +708,7 @@ TEST_F(CpuidX86Test, AMD_K18_ZEN_DHYANA) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "HygonGenuine");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_HYGON_GENUINE);
   EXPECT_EQ(info.family, 0x18);
   EXPECT_EQ(info.model, 0x00);
   EXPECT_STREQ(info.brand_string,
@@ -778,7 +778,7 @@ TEST_F(CpuidX86Test, AMD_K19_ZEN3_VERMEER) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x19);
   EXPECT_EQ(info.model, 0x21);
   EXPECT_STREQ(info.brand_string,
@@ -799,7 +799,7 @@ TEST_F(CpuidX86Test, AMD_K19_ZEN3) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "AuthenticAMD");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_AUTHENTIC_AMD);
   EXPECT_EQ(info.family, 0x19);
   EXPECT_EQ(info.model, 0x44);
   EXPECT_STREQ(info.brand_string,
@@ -822,7 +822,7 @@ TEST_F(CpuidX86Test, AMD_K18_ZEN_DHYANA_OCTAL_CORE_C86_3250) {
 
   EXPECT_EQ(info.model, 0x01);
   EXPECT_EQ(info.family, 0x18);
-  EXPECT_STREQ(info.vendor, "HygonGenuine");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_HYGON_GENUINE);
   EXPECT_STREQ(info.brand_string,
                "Hygon C86 3250  8-core Processor               ");
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::AMD_ZEN);
@@ -909,7 +909,7 @@ flags           : fpu mmx sse sse2 pni ssse3 sse4_1 sse4_2
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x1A);
   EXPECT_EQ(info.stepping, 0x02);
@@ -987,7 +987,7 @@ flags           : fpu mmx sse sse2 pni ssse3 sse4_1 sse4_2
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x37);
   EXPECT_EQ(info.stepping, 0x03);
@@ -1087,7 +1087,7 @@ flags           : fpu mmx sse
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x07);
   EXPECT_EQ(info.stepping, 0x03);
@@ -1111,7 +1111,7 @@ TEST_F(CpuidX86Test, INTEL_80486) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x04);
   EXPECT_EQ(info.model, 0x08);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_80486);
@@ -1125,7 +1125,7 @@ TEST_F(CpuidX86Test, INTEL_P54C) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x05);
   EXPECT_EQ(info.model, 0x02);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_P5);
@@ -1139,7 +1139,7 @@ TEST_F(CpuidX86Test, INTEL_LAKEMONT) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x05);
   EXPECT_EQ(info.model, 0x09);
   EXPECT_EQ(GetX86Microarchitecture(&info),
@@ -1154,7 +1154,7 @@ TEST_F(CpuidX86Test, INTEL_KNIGHTS_LANDING) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x57);
   EXPECT_EQ(GetX86Microarchitecture(&info),
@@ -1169,7 +1169,7 @@ TEST_F(CpuidX86Test, INTEL_CML_U) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x8E);
   EXPECT_EQ(info.stepping, 0x0C);
@@ -1184,7 +1184,7 @@ TEST_F(CpuidX86Test, INTEL_CML_H) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0xA5);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_CML);
@@ -1198,7 +1198,7 @@ TEST_F(CpuidX86Test, INTEL_ATOM_TMT_LAKEFIELD) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x8A);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_ATOM_TMT);
@@ -1212,7 +1212,7 @@ TEST_F(CpuidX86Test, INTEL_ATOM_TMT_ELKHART_LAKE) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x96);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_ATOM_TMT);
@@ -1226,7 +1226,7 @@ TEST_F(CpuidX86Test, INTEL_ATOM_TMT_JASPER_LAKE) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x9C);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_ATOM_TMT);
@@ -1243,7 +1243,7 @@ TEST_F(CpuidX86Test, INTEL_HASWELL_LZCNT) {
   });
   const auto info = GetX86Info();
 
-  EXPECT_STREQ(info.vendor, "GenuineIntel");
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
   EXPECT_EQ(info.family, 0x06);
   EXPECT_EQ(info.model, 0x3F);
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_HSW);


### PR DESCRIPTION
I have added in this PR replacing of hardcoded values to constants `CPU_FEATURES_VENDOR_GENUINE_INTEL`, `CPU_FEATURES_VENDOR_AUTHENTIC_AMD` and `CPU_FEATURES_VENDOR_HYGON_GENUINE`

ref: https://github.com/google/cpu_features/blob/426b036e8dc04a296c8e837745d7fa187f57670d/include/cpuinfo_x86.h#L24-L29