### PR TITLE
add x86/avx512_fp16 detection

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -82,6 +82,7 @@ typedef struct {
   int avx512_4fmaps : 1;
   int avx512_bf16 : 1;
   int avx512_vp2intersect : 1;
+  int avx512_fp16 : 1;
   int amx_bf16 : 1;
   int amx_tile : 1;
   int amx_int8 : 1;
@@ -239,6 +240,7 @@ typedef enum {
   X86_AVX512_4FMAPS,
   X86_AVX512_BF16,
   X86_AVX512_VP2INTERSECT,
+  X86_AVX512_FP16,
   X86_AMX_BF16,
   X86_AMX_TILE,
   X86_AMX_INT8,

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -365,6 +365,7 @@ static void ParseCpuId(const Leaves* leaves, X86Info* info,
       features->avx512_4fmaps = IsBitSet(leaf_7.edx, 3);
       features->avx512_bf16 = IsBitSet(leaf_7_1.eax, 5);
       features->avx512_vp2intersect = IsBitSet(leaf_7.edx, 8);
+      features->avx512_fp16 = IsBitSet(leaf_7.edx, 23);
     }
     if (os_preserves->amx_registers) {
       features->amx_bf16 = IsBitSet(leaf_7.edx, 22);
@@ -1877,6 +1878,7 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(X86_AVX512_4FMAPS, avx512_4fmaps, , , )             \
   LINE(X86_AVX512_BF16, avx512_bf16, , , )                 \
   LINE(X86_AVX512_VP2INTERSECT, avx512_vp2intersect, , , ) \
+  LINE(X86_AVX512_FP16, avx512_fp16, , , )                 \
   LINE(X86_AMX_BF16, amx_bf16, , , )                       \
   LINE(X86_AMX_TILE, amx_tile, , , )                       \
   LINE(X86_AMX_INT8, amx_int8, , , )                       \

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -923,6 +923,73 @@ TEST_F(CpuidX86Test, INTEL_ALDER_LAKE_AVX_VNNI) {
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_ADL);
 }
 
+// https://github.com/InstLatx64/InstLatx64/blob/master/GenuineIntel/GenuineIntel0090672_AlderLake_BC_AVX512_CPUID01.txt
+TEST_F(CpuidX86Test, INTEL_ALDER_LAKE_AVX512) {
+  cpu().SetOsBackupsExtendedRegisters(true);
+#if defined(CPU_FEATURES_OS_MACOS)
+  cpu().SetDarwinSysCtlByName("hw.optional.avx512f");
+#endif
+  cpu().SetLeaves({
+      {{0x00000000, 0}, Leaf{0x00000020, 0x756E6547, 0x6C65746E, 0x49656E69}},
+      {{0x00000001, 0}, Leaf{0x000906A4, 0x00400800, 0x7FFAFBBF, 0xBFEBFBFF}},
+      {{0x00000007, 0}, Leaf{0x00000001, 0xF3BFA7EB, 0x98C07FEE, 0xFC9CC510}},
+      {{0x00000007, 1}, Leaf{0x00401C30, 0x00000000, 0x00000000, 0x00000000}},
+  });
+
+  const auto info = GetX86Info();
+
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
+  EXPECT_EQ(info.family, 0x06);
+  EXPECT_EQ(info.model, 0x9A);
+  EXPECT_TRUE(info.features.avx512f);
+  EXPECT_TRUE(info.features.avx512bw);
+  EXPECT_TRUE(info.features.avx512dq);
+  EXPECT_TRUE(info.features.avx512cd);
+  EXPECT_TRUE(info.features.avx512vl);
+  EXPECT_TRUE(info.features.avx512_vp2intersect);
+  EXPECT_TRUE(info.features.avx512vbmi);
+  EXPECT_TRUE(info.features.avx512vbmi2);
+  EXPECT_TRUE(info.features.avx512bitalg);
+  EXPECT_TRUE(info.features.avx512vpopcntdq);
+  EXPECT_TRUE(info.features.avx512ifma);
+  EXPECT_TRUE(info.features.avx512_bf16);
+  EXPECT_TRUE(info.features.avx512_fp16);
+
+  EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_ADL);
+}
+
+// https://github.com/InstLatx64/InstLatx64/blob/master/GenuineIntel/GenuineIntel00806C1_TigerLake_CPUID3.txt
+TEST_F(CpuidX86Test, INTEL_TIGER_LAKE_AVX512) {
+  cpu().SetOsBackupsExtendedRegisters(true);
+#if defined(CPU_FEATURES_OS_MACOS)
+  cpu().SetDarwinSysCtlByName("hw.optional.avx512f");
+#endif
+  cpu().SetLeaves({
+      {{0x00000000, 0}, Leaf{0x0000001B, 0x756E6547, 0x6C65746E, 0x49656E69}},
+      {{0x00000001, 0}, Leaf{0x000806C1, 0x00100800, 0x7FFAFBBF, 0xBFEBFBFF}},
+      {{0x00000007, 0}, Leaf{0x00000000, 0xF3BFA7EB, 0x18C05FCE, 0xFC100510}},
+  });
+
+  const auto info = GetX86Info();
+
+  EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
+  EXPECT_EQ(info.family, 0x06);
+  EXPECT_EQ(info.model, 0x8C);
+  EXPECT_TRUE(info.features.avx512f);
+  EXPECT_TRUE(info.features.avx512bw);
+  EXPECT_TRUE(info.features.avx512dq);
+  EXPECT_TRUE(info.features.avx512cd);
+  EXPECT_TRUE(info.features.avx512vl);
+  EXPECT_TRUE(info.features.avx512_vp2intersect);
+  EXPECT_TRUE(info.features.avx512vbmi);
+  EXPECT_TRUE(info.features.avx512vbmi2);
+  EXPECT_TRUE(info.features.avx512bitalg);
+  EXPECT_TRUE(info.features.avx512vpopcntdq);
+  EXPECT_TRUE(info.features.avx512ifma);
+
+  EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_TGL);
+}
+
 // http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0100FA0_K10_Thuban_CPUID.txt
 TEST_F(CpuidX86Test, AMD_THUBAN_CACHE_INFO) {
   cpu().SetLeaves({


### PR DESCRIPTION
For reference, on an alder-lake CPU with `AVX512` (and therefore, `AVX512_FP16` support) enabled:

```shell
$ ./list_cpu_features
arch            : x86
brand           : 12th Gen Intel(R) Core(TM) i9-12900K
family          :   6 (0x06)
model           : 151 (0x97)
stepping        :   2 (0x02)
uarch           : INTEL_ADL
flags           : adx,aes,avx,avx2,avx512_bf16,avx512_fp16,avx512_second_fma,avx512_vp2intersect,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,avx_vnni,bmi1,bmi2,clflushopt,clfsh,clwb,cx16,cx8,erms,f16c,fma3,fpu,lzcnt,mmx,movbe,pclmulqdq,popcnt,rdrnd,rdseed,sha,smx,ss,sse,sse2,sse3,sse4_1,sse4_2,ssse3,tsc,vaes,vpclmulqdq
cache_info      : {"level":1,"cache_type":"data","cache_size":49152,"ways":12,"line_size":64,"tlb_entries":64,"partitioning":1},{"level":1,"cache_type":"instruction","cache_size":32768,"ways":8,"line_size":64,"tlb_entries":64,"partitioning":1},{"level":2,"cache_type":"unified","cache_size":1310720,"ways":10,"line_size":64,"tlb_entries":2048,"partitioning":1},{"level":3,"cache_type":"unified","cache_size":31457280,"ways":12,"line_size":64,"tlb_entries":40960,"partitioning":1}
```

On a tiger-lake laptop, predating `AVX512_FP16` support:

```shell
$ arch            : x86
brand           : 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
family          :   6 (0x06)
model           : 140 (0x8C)
stepping        :   1 (0x01)
uarch           : INTEL_TGL
flags           : adx,aes,avx,avx2,avx512_second_fma,avx512_vp2intersect,avx512bitalg,avx512bw,avx512cd,avx512dq,avx512f,avx512ifma,avx512vbmi,avx512vbmi2,avx512vl,avx512vnni,avx512vpopcntdq,bmi1,bmi2,clflushopt,clfsh,clwb,cx16,cx8,erms,f16c,fma3,fpu,lzcnt,mmx,movbe,pclmulqdq,popcnt,rdrnd,rdseed,sha,ss,sse,sse2,sse3,sse4_1,sse4_2,ssse3,tsc,vaes,vpclmulqdq
cache_info      : {"level":1,"cache_type":"data","cache_size":49152,"ways":12,"line_size":64,"tlb_entries":64,"partitioning":1},{"level":1,"cache_type":"instruction","cache_size":32768,"ways":8,"line_size":64,"tlb_entries":64,"partitioning":1},{"level":2,"cache_type":"unified","cache_size":1310720,"ways":20,"line_size":64,"tlb_entries":1024,"partitioning":1},{"level":3,"cache_type":"unified","cache_size":12582912,"ways":12,"line_size":64,"tlb_entries":16384,"partitioning":1}
```