### PR TITLE
Add X86 GFNI detection

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -100,6 +100,7 @@ typedef struct {
   int ss : 1;
   int adx : 1;
   int lzcnt : 1;  // Note: this flag is called ABM for AMD, LZCNT for Intel.
+  int gfni: 1;
   // Make sure to update X86FeaturesEnum below if you add a field here.
 } X86Features;
 
@@ -256,6 +257,7 @@ typedef enum {
   X86_SS,
   X86_ADX,
   X86_LZCNT,
+  X86_GFNI,
   X86_LAST_,
 } X86FeaturesEnum;
 

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -310,6 +310,7 @@ static void ParseCpuId(const Leaves* leaves, X86Info* info,
   features->clflushopt = IsBitSet(leaf_7.ebx, 23);
   features->clwb = IsBitSet(leaf_7.ebx, 24);
   features->sha = IsBitSet(leaf_7.ebx, 29);
+  features->gfni = IsBitSet(leaf_7.ecx, 8);
   features->vaes = IsBitSet(leaf_7.ecx, 9);
   features->vpclmulqdq = IsBitSet(leaf_7.ecx, 10);
   features->adx = IsBitSet(leaf_7.ebx, 19);
@@ -1895,7 +1896,8 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(X86_DCA, dca, , , )                                 \
   LINE(X86_SS, ss, , , )                                   \
   LINE(X86_ADX, adx, , , )                                 \
-  LINE(X86_LZCNT, lzcnt, , , )
+  LINE(X86_LZCNT, lzcnt, , , )                             \
+  LINE(X86_GFNI, gfni, , , )
 #define INTROSPECTION_PREFIX X86
 #define INTROSPECTION_ENUM_PREFIX X86
 #include "define_introspection.inl"

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -1011,6 +1011,24 @@ TEST_F(CpuidX86Test, INTEL_TIGER_LAKE_AVX512) {
   EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_TGL);
 }
 
+// http://users.atw.hu/instlatx64/GenuineIntel/GenuineIntel00706E5_IceLakeY_CPUID.txt
+TEST_F(CpuidX86Test, INTEL_ICE_LAKE_GFNI) {
+    cpu().SetLeaves({
+        {{0x00000000, 0}, Leaf{0x0000001B, 0x756E6547, 0x6C65746E, 0x49656E69}},
+        {{0x00000001, 0}, Leaf{0x000706E5, 0x00100800, 0x7FFAFBBF, 0xBFEBFBFF}},
+        {{0x00000007, 0}, Leaf{0x00000000, 0xF2BF27EF, 0x40405F4E, 0xBC000410}},
+    });
+
+    const auto info = GetX86Info();
+
+    EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
+    EXPECT_EQ(info.family, 0x06);
+    EXPECT_EQ(info.model, 0x7E);
+    EXPECT_TRUE(info.features.gfni);
+
+    EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_ICL);
+}
+
 // http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0100FA0_K10_Thuban_CPUID.txt
 TEST_F(CpuidX86Test, AMD_THUBAN_CACHE_INFO) {
   cpu().SetLeaves({


### PR DESCRIPTION
In this PR I added GFNI detection:
Intel® 64 and IA-32 Architectures Software Developer’s Manual Volume 2 Page 323
CPUID.0000_0007_ECX[8]: GFNI support