### PR TITLE
Add X86 MOVDIRI/MOVDIR64B detection

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -101,6 +101,8 @@ typedef struct {
   int adx : 1;
   int lzcnt : 1;  // Note: this flag is called ABM for AMD, LZCNT for Intel.
   int gfni: 1;
+  int movdiri: 1;
+  int movdir64b: 1;
   // Make sure to update X86FeaturesEnum below if you add a field here.
 } X86Features;
 
@@ -258,6 +260,8 @@ typedef enum {
   X86_ADX,
   X86_LZCNT,
   X86_GFNI,
+  X86_MOVDIRI,
+  X86_MOVDIR64B,
   X86_LAST_,
 } X86FeaturesEnum;
 

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -313,6 +313,8 @@ static void ParseCpuId(const Leaves* leaves, X86Info* info,
   features->gfni = IsBitSet(leaf_7.ecx, 8);
   features->vaes = IsBitSet(leaf_7.ecx, 9);
   features->vpclmulqdq = IsBitSet(leaf_7.ecx, 10);
+  features->movdiri = IsBitSet(leaf_7.ecx, 27);
+  features->movdir64b = IsBitSet(leaf_7.ecx, 28);
   features->adx = IsBitSet(leaf_7.ebx, 19);
   features->lzcnt = IsBitSet(leaf_80000001.ecx, 5);
 
@@ -1897,7 +1899,9 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(X86_SS, ss, , , )                                   \
   LINE(X86_ADX, adx, , , )                                 \
   LINE(X86_LZCNT, lzcnt, , , )                             \
-  LINE(X86_GFNI, gfni, , , )
+  LINE(X86_GFNI, gfni, , , )                               \
+  LINE(X86_MOVDIRI, movdiri, , , )                         \
+  LINE(X86_MOVDIR64B, movdir64b, , , )
 #define INTROSPECTION_PREFIX X86
 #define INTROSPECTION_ENUM_PREFIX X86
 #include "define_introspection.inl"

--- a/test/cpuinfo_x86_test.cc
+++ b/test/cpuinfo_x86_test.cc
@@ -1029,6 +1029,25 @@ TEST_F(CpuidX86Test, INTEL_ICE_LAKE_GFNI) {
     EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_ICL);
 }
 
+// http://users.atw.hu/instlatx64/GenuineIntel/GenuineIntel00906C0_JasperLake_CPUID01.txt
+TEST_F(CpuidX86Test, INTEL_TREMONT_JASPER_LAKE_MOVDR) {
+    cpu().SetLeaves({
+        {{0x00000000, 0}, Leaf{0x0000001B, 0x756E6547, 0x6C65746E, 0x49656E69}},
+        {{0x00000001, 0}, Leaf{0x00090661, 0x00800800, 0x4FF8EBBF, 0xBFEBFBFF}},
+        {{0x00000007, 0}, Leaf{0x00000000, 0x2394A2C3, 0x18400124, 0xFC000400}},
+    });
+
+    const auto info = GetX86Info();
+
+    EXPECT_STREQ(info.vendor, CPU_FEATURES_VENDOR_GENUINE_INTEL);
+    EXPECT_EQ(info.family, 0x06);
+    EXPECT_EQ(info.model, 0x96);
+    EXPECT_TRUE(info.features.movdiri);
+    EXPECT_TRUE(info.features.movdir64b);
+
+    EXPECT_EQ(GetX86Microarchitecture(&info), X86Microarchitecture::INTEL_ATOM_TMT);
+}
+
 // http://users.atw.hu/instlatx64/AuthenticAMD/AuthenticAMD0100FA0_K10_Thuban_CPUID.txt
 TEST_F(CpuidX86Test, AMD_THUBAN_CACHE_INFO) {
   cpu().SetLeaves({


### PR DESCRIPTION
In this PR I added the detection of movdir instructions
refs:
https://www.felixcloutier.com/x86/movdiri
https://www.felixcloutier.com/x86/movdir64b
[architecture-instruction-set-extensions-programming-reference page 26](https://software.intel.com/sites/default/files/managed/c5/15/architecture-instruction-set-extensions-programming-reference.pdf)
