### PR TITLE
Add RISC-V CI support

### DIFF
--- a/.github/workflows/riscv_linux_cmake.yml
+++ b/.github/workflows/riscv_linux_cmake.yml
@@ -1,0 +1,28 @@
+name: RISCV Linux CMake
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # min hours day(month) month day(week)
+    - cron: '0 0 7,22 * *'
+
+jobs:
+  # Building using the github runner environement directly.
+  make:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        targets: [
+          [riscv32],
+          [riscv64],
+        ]
+      fail-fast: false
+    env:
+      TARGET: ${{ matrix.targets[0] }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: make --directory=cmake/ci ${TARGET}_build
+    - name: Test
+      run: make --directory=cmake/ci ${TARGET}_test

--- a/cmake/ci/Makefile
+++ b/cmake/ci/Makefile
@@ -55,6 +55,8 @@ help:
 	@echo -e "\t\t${BOLD}ppc${RESET} (bootlin toolchain)"
 	@echo -e "\t\t${BOLD}ppc64${RESET} (bootlin toolchain)"
 	@echo -e "\t\t${BOLD}ppc64le${RESET} (bootlin toolchain)"
+	@echo -e "\t\t${BOLD}riscv32${RESET} (bootlin toolchain)"
+	@echo -e "\t\t${BOLD}riscv64${RESET} (bootlin toolchain)"
 	@echo -e "\t\t${BOLD}s390x${RESET} (bootlin toolchain)"
 	@echo
 	@echo -e "\tWith ${BOLD}<toolchain_stage>${RESET}:"
@@ -154,6 +156,7 @@ TOOLCHAIN_TARGETS = \
  aarch64-linux-gnu aarch64_be-linux-gnu \
  mips32 mips32el mips64 mips64el \
  ppc ppc64 ppc64le \
+ riscv32 riscv64 \
  s390x
 TOOLCHAIN_STAGES = env devel build test
 define toolchain-stage-target =

--- a/scripts/generate_badges.d
+++ b/scripts/generate_badges.d
@@ -18,8 +18,9 @@ enum Cpu
     AArch64,
     ARM,
     MIPS,
-    s390x,
     POWER,
+    RISCV,
+    s390x,
 }
 
 enum Os

--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -162,6 +162,14 @@ function expand_bootlin_config() {
       local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-440fp/tarballs/powerpc-440fp--glibc--stable-2021.11-1.tar.bz2"
       local -r GCC_PREFIX="powerpc"
       ;;
+    "riscv32")
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/riscv32-ilp32d/tarballs/riscv32-ilp32d--glibc--bleeding-edge-2022.08-1.tar.bz2"
+      local -r GCC_PREFIX="riscv32"
+      ;;
+    "riscv64")
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/riscv64-lp64d/tarballs/riscv64-lp64d--glibc--stable-2022.08-1.tar.bz2"
+      local -r GCC_PREFIX="riscv64"
+      ;;
     "s390x")
       local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/s390x-z13/tarballs/s390x-z13--glibc--stable-2022.08-1.tar.bz2"
       local -r GCC_PREFIX="s390x"
@@ -357,6 +365,7 @@ DESCRIPTION
 \t\tmips64 mips64el (codespace)
 \t\tppc (bootlin)
 \t\tppc64 ppc64le (bootlin)
+\t\triscv32 riscv64 (bootlin)
 \t\ts390x (bootlin)
 
 OPTIONS
@@ -443,6 +452,12 @@ function main() {
     ppc)
       expand_bootlin_config
       declare -r QEMU_ARCH=ppc ;;
+    riscv32)
+      expand_bootlin_config
+      declare -r QEMU_ARCH=riscv32 ;;
+    riscv64)
+      expand_bootlin_config
+      declare -r QEMU_ARCH=riscv64 ;;
     s390x)
       expand_bootlin_config
       declare -r QEMU_ARCH=s390x ;;

--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -142,28 +142,28 @@ function expand_bootlin_config() {
 
   case "${TARGET}" in
     "aarch64")
-      local -r POWER_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/aarch64--glibc--stable-2021.11-1.tar.bz2"
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/aarch64--glibc--stable-2021.11-1.tar.bz2"
       local -r GCC_PREFIX="aarch64"
       ;;
     "aarch64be")
-      local -r POWER_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64be/tarballs/aarch64be--glibc--stable-2021.11-1.tar.bz2"
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64be/tarballs/aarch64be--glibc--stable-2021.11-1.tar.bz2"
       local -r GCC_PREFIX="aarch64_be"
       ;;
     "ppc64le")
-      local -r POWER_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc64le-power8/tarballs/powerpc64le-power8--glibc--stable-2021.11-1.tar.bz2"
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc64le-power8/tarballs/powerpc64le-power8--glibc--stable-2021.11-1.tar.bz2"
       local -r GCC_PREFIX="powerpc64le"
       ;;
     "ppc64")
-      local -r POWER_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc64-power8/tarballs/powerpc64-power8--glibc--stable-2021.11-1.tar.bz2"
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc64-power8/tarballs/powerpc64-power8--glibc--stable-2021.11-1.tar.bz2"
       local -r GCC_PREFIX="powerpc64"
       ;;
     "ppc")
-      #local -r POWER_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-e500mc/tarballs/powerpc-e500mc--glibc--stable-2021.11-1.tar.bz2"
-      local -r POWER_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-440fp/tarballs/powerpc-440fp--glibc--stable-2021.11-1.tar.bz2"
+      #local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-e500mc/tarballs/powerpc-e500mc--glibc--stable-2021.11-1.tar.bz2"
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-440fp/tarballs/powerpc-440fp--glibc--stable-2021.11-1.tar.bz2"
       local -r GCC_PREFIX="powerpc"
       ;;
     "s390x")
-      local -r POWER_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/s390x-z13/tarballs/s390x-z13--glibc--stable-2022.08-1.tar.bz2"
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/s390x-z13/tarballs/s390x-z13--glibc--stable-2022.08-1.tar.bz2"
       local -r GCC_PREFIX="s390x"
       ;;
     *)
@@ -171,16 +171,16 @@ function expand_bootlin_config() {
       exit 1 ;;
   esac
 
-  local -r POWER_RELATIVE_DIR="${TARGET}"
-  unpack "${POWER_URL}" "${POWER_RELATIVE_DIR}"
-  local -r EXTRACT_DIR="${ARCHIVE_DIR}/$(basename ${POWER_URL%.tar.bz2})"
+  local -r TOOLCHAIN_RELATIVE_DIR="${TARGET}"
+  unpack "${TOOLCHAIN_URL}" "${TOOLCHAIN_RELATIVE_DIR}"
+  local -r EXTRACT_DIR="${ARCHIVE_DIR}/$(basename ${TOOLCHAIN_URL%.tar.bz2})"
 
-  local -r POWER_DIR=${ARCHIVE_DIR}/${POWER_RELATIVE_DIR}
+  local -r TOOLCHAIN_DIR=${ARCHIVE_DIR}/${TOOLCHAIN_RELATIVE_DIR}
   if [[ -d "${EXTRACT_DIR}" ]]; then
-    mv "${EXTRACT_DIR}" "${POWER_DIR}"
+    mv "${EXTRACT_DIR}" "${TOOLCHAIN_DIR}"
   fi
 
-  local -r SYSROOT_DIR="${POWER_DIR}/${GCC_PREFIX}-buildroot-linux-gnu/sysroot"
+  local -r SYSROOT_DIR="${TOOLCHAIN_DIR}/${GCC_PREFIX}-buildroot-linux-gnu/sysroot"
   #local -r STAGING_DIR=${SYSROOT_DIR}-stage
 
   # Write a Toolchain file
@@ -194,14 +194,14 @@ set(CMAKE_SYSTEM_PROCESSOR ${GCC_PREFIX})
 set(CMAKE_SYSROOT ${SYSROOT_DIR})
 #set(CMAKE_STAGING_PREFIX ${STAGING_DIR})
 
-set(tools ${POWER_DIR})
+set(tools ${TOOLCHAIN_DIR})
 
 set(CMAKE_C_COMPILER \${tools}/bin/${GCC_PREFIX}-linux-gcc)
 set(CMAKE_C_FLAGS "${POWER_FLAGS}")
 set(CMAKE_CXX_COMPILER \${tools}/bin/${GCC_PREFIX}-linux-g++)
 set(CMAKE_CXX_FLAGS "${POWER_FLAGS} -L${SYSROOT_DIR}/lib")
 
-set(CMAKE_FIND_ROOT_PATH ${POWER_DIR})
+set(CMAKE_FIND_ROOT_PATH ${TOOLCHAIN_DIR})
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
This follow(Fix) or precede(TDD):
* #272

This PR add:
* CI: Add riscv support
  * [x] Add bootlin toolchain in `scripts/run_integration.sh`
  * [x] Add riscv support in `cmake/ci/Makefile`
  * [x] Add `riskv_linux_cmake.yml` workflows
  * [x] Add RISCV to badge script (todo(gchatelet): rerun it to regenerate README.md)
* Fixup: variable fixup in expand_bootlin (ed `s/POWER_/TOOLCHAIN_/`)

note: I've sorted arch badges alphabetically...