### PR TITLE
Include tests when using QEMU

### DIFF
--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -330,7 +330,10 @@ function run_test() {
 
   cd "${BUILD_DIR}" || exit 2
   set -x
-  for test_binary in "${BUILD_DIR}"/list_cpu_feature* ; do
+  declare -a TEST_BINARIES=()
+  TEST_BINARIES+=($(find "${BUILD_DIR}"/test -executable -type f))
+  TEST_BINARIES+=($(find "${BUILD_DIR}" -maxdepth 1 -executable -type f))
+  for test_binary in ${TEST_BINARIES[*]} ; do
       ${RUN_CMD} "${test_binary}"
   done
   set +x

--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -329,13 +329,15 @@ function run_test() {
   RUN_CMD="${QEMU_INSTALL}/bin/qemu-${QEMU_ARCH} ${QEMU_ARGS[*]}"
 
   cd "${BUILD_DIR}" || exit 2
-  set -x
   declare -a TEST_BINARIES=()
   TEST_BINARIES+=($(find "${BUILD_DIR}"/test -executable -type f))
   TEST_BINARIES+=($(find "${BUILD_DIR}" -maxdepth 1 -executable -type f))
+  set -x
+  set -e
   for test_binary in ${TEST_BINARIES[*]} ; do
       ${RUN_CMD} "${test_binary}"
   done
+  set +e
   set +x
 }
 


### PR DESCRIPTION
We may be able to use [CMAKE_CROSSCOMPILING_EMULATOR](https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING_EMULATOR.html) in the future but it's easier to just use run the tests under qemu.

BTW it may be necessary to enclose qemu's run with a `set -e` / `set +e`.