### PR TITLE
Update C++ standard for tests from C++11 to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,9 +179,9 @@ if(BUILD_TESTING)
   # found.
   enable_language(CXX)
 
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 14)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF) # prefer use of -std11 instead of -gnustd11
+  set(CMAKE_CXX_EXTENSIONS OFF) # prefer use of -std14 instead of -gnustd14
 
   if(NOT TARGET gtest OR NOT TARGET gmock_main)
     # Download and unpack googletest at configure time.


### PR DESCRIPTION
Since 1.13.0, gtest requires at least C++14. When it is automatically downloaded and compiled, gtest’s CMake scripts override the C++ standard, so the tests are compiled in C++14 mode already. Changing the C++ standard in cpu_features will make it easier for users such as Linux distribution packagers who are linking against an external or system-wide copy of gtest 1.13.0 or later.