### PR TITLE
Add 'ndk_compat' include directory to 'ndk_compat' target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -332,7 +332,7 @@ cc_library(
     name = "ndk_compat",
     srcs = ["ndk_compat/cpu-features.c"],
     copts = C99_FLAGS,
-    includes = INCLUDES,
+    includes = INCLUDES + ["ndk_compat"],
     textual_hdrs = ["ndk_compat/cpu-features.h"],
     deps = [
         ":cpu_features_macros",


### PR DESCRIPTION
Add 'ndk_compat' to the 'includes' directive of the 'ndk_compat' target, so that targets that include this library can directly reference 'cpu-features.h' like they did with the legacy Android NDK library.