### PR TITLE
Add Intel AMX-FP16 detection

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -86,6 +86,7 @@ typedef struct {
   int amx_bf16 : 1;
   int amx_tile : 1;
   int amx_int8 : 1;
+  int amx_fp16 : 1;
 
   int pclmulqdq : 1;
   int smx : 1;
@@ -254,6 +255,7 @@ typedef enum {
   X86_AMX_BF16,
   X86_AMX_TILE,
   X86_AMX_INT8,
+  X86_AMX_FP16,
   X86_PCLMULQDQ,
   X86_SMX,
   X86_SGX,

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -450,6 +450,7 @@ static void ParseCpuId(const Leaves* leaves, X86Info* info,
       features->amx_bf16 = IsBitSet(leaf_7.edx, 22);
       features->amx_tile = IsBitSet(leaf_7.edx, 24);
       features->amx_int8 = IsBitSet(leaf_7.edx, 25);
+      features->amx_fp16 = IsBitSet(leaf_7_1.eax, 21);
     }
   } else {
     // When XCR0 is not available (Atom based or older cpus) we need to defer to
@@ -1972,6 +1973,7 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(X86_AMX_BF16, amx_bf16, , , )                       \
   LINE(X86_AMX_TILE, amx_tile, , , )                       \
   LINE(X86_AMX_INT8, amx_int8, , , )                       \
+  LINE(X86_AMX_FP16, amx_fp16, , , )                       \
   LINE(X86_PCLMULQDQ, pclmulqdq, , , )                     \
   LINE(X86_SMX, smx, , , )                                 \
   LINE(X86_SGX, sgx, , , )                                 \


### PR DESCRIPTION
https://cdrdv2-public.intel.com/774990/architecture-instruction-set-extensions-programming-reference.pdf
this instruction set will be in future Granite Rapids (~2024-2025)

![image](https://github.com/google/cpu_features/assets/43444946/183c5a36-0947-4a03-8529-ae016b2bf5b0)

llvm https://github.com/llvm/llvm-project/blob/9f3e3efd98a29eb8df9e3ad43a573c9141d1ace2/clang/lib/Basic/Targets/X86.cpp#L834