### PR TITLE
cmake: Use CpuFeatures:: as TARGET namespace (Fix #333)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ target_include_directories(cpu_features
 if(APPLE)
   target_compile_definitions(cpu_features PRIVATE HAVE_SYSCTLBYNAME)
 endif()
-add_library(CpuFeature::cpu_features ALIAS cpu_features)
+add_library(CpuFeatures::cpu_features ALIAS cpu_features)
 
 #
 # program : list_cpu_features
@@ -189,7 +189,7 @@ add_library(CpuFeature::cpu_features ALIAS cpu_features)
 if(BUILD_EXECUTABLE)
   add_executable(list_cpu_features ${PROJECT_SOURCE_DIR}/src/utils/list_cpu_features.c)
   target_link_libraries(list_cpu_features PRIVATE cpu_features)
-  add_executable(CpuFeature::list_cpu_features ALIAS list_cpu_features)
+  add_executable(CpuFeatures::list_cpu_features ALIAS list_cpu_features)
 endif()
 
 #

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -17,7 +17,7 @@ or add cpu_features as a git-submodule in your project
 2- You can then use the cmake command `add_subdirectory()` to include
 cpu_features directly and use the `cpu_features` target in your project.
 
-3- Add the `CpuFeature::cpu_features` target to the `target_link_libraries()` section of
+3- Add the `CpuFeatures::cpu_features` target to the `target_link_libraries()` section of
 your executable or of your library.
 
 ## Disabling tests


### PR DESCRIPTION
Use `CpuFeatures::` for ALIAS since this is the name we already use for `install(EXPORT)`...

note: currently CI test using cmake install step, I don't know if we should also add a job to check if using `CpuFeatures::cpu_features` using `add_subdirectory()`/`FetchContent()` is also working as expected (both will rely on the `ALIAS`...)