### PR TITLE
fix -Wstrict-prototypes error

### DIFF
--- a/src/hwcaps_linux_or_android.c
+++ b/src/hwcaps_linux_or_android.c
@@ -153,7 +153,7 @@ const char *CpuFeatures_GetBasePlatformPointer(void) {
   return (const char *)GetHardwareCapabilitiesFor(AT_BASE_PLATFORM);
 }
 
-bool CpuFeatures_IsHwCapCpuidSupported() {
+bool CpuFeatures_IsHwCapCpuidSupported(void) {
   return GetElfHwcapFromGetauxval(AARCH64_HWCAP_CPUID);
 }
 


### PR DESCRIPTION
note: tested using: `add_compile_options("-Werror" "-Wstrict-prototypes")`