### PR TITLE
Remove unused function

### DIFF
--- a/src/hwcaps_linux_or_android.c
+++ b/src/hwcaps_linux_or_android.c
@@ -153,9 +153,5 @@ const char *CpuFeatures_GetBasePlatformPointer(void) {
   return (const char *)GetHardwareCapabilitiesFor(AT_BASE_PLATFORM);
 }
 
-bool CpuFeatures_IsHwCapCpuidSupported(void) {
-  return GetElfHwcapFromGetauxval(AARCH64_HWCAP_CPUID);
-}
-
 #endif  // CPU_FEATURES_TEST
 #endif  // defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID)


### PR DESCRIPTION
This is causing the build to fail with stricter warnings.
`error: no previous prototype for function 'CpuFeatures_IsHwCapCpuidSupported' [-Werror,-Wmissing-prototypes]`