### PR TITLE
Add ECV flag on macOS/iOS

### DIFF
--- a/src/impl_aarch64_macos_or_iphone.c
+++ b/src/impl_aarch64_macos_or_iphone.c
@@ -81,6 +81,7 @@ Aarch64Info GetAarch64Info(void) {
   info.features.i8mm = GetDarwinSysCtlByName("hw.optional.arm.FEAT_I8MM");
   info.features.bf16 = GetDarwinSysCtlByName("hw.optional.arm.FEAT_BF16");
   info.features.bti = GetDarwinSysCtlByName("hw.optional.arm.FEAT_BTI");
+  info.features.ecv = GetDarwinSysCtlByName("hw.optional.arm.FEAT_ECV");
 
   return info;
 }

--- a/test/cpuinfo_aarch64_test.cc
+++ b/test/cpuinfo_aarch64_test.cc
@@ -373,6 +373,7 @@ TEST_F(CpuidAarch64Test, FromDarwinSysctlFromName) {
   EXPECT_FALSE(info.features.sb);
   EXPECT_FALSE(info.features.paca);
   EXPECT_FALSE(info.features.pacg);
+  EXPECT_FALSE(info.features.ecv);
 }
 #elif defined(CPU_FEATURES_OS_WINDOWS)
 TEST_F(CpuidAarch64Test, WINDOWS_AARCH64_RPI4) {


### PR DESCRIPTION
This flag comes directly from [Apple's own page on sysctl names](https://developer.apple.com/documentation/kernel/1387446-sysctlbyname/determining_instruction_set_characteristics).