### PR TITLE
Add avxifma feature detection on x86

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -62,6 +62,7 @@ typedef struct {
   int avx : 1;
   int avx_vnni : 1;
   int avx2 : 1;
+  int avxifma : 1;
 
   int avx512f : 1;
   int avx512cd : 1;
@@ -232,6 +233,7 @@ typedef enum {
   X86_AVX,
   X86_AVX_VNNI,
   X86_AVX2,
+  X86_AVXIFMA,
   X86_AVX512F,
   X86_AVX512CD,
   X86_AVX512ER,

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -423,6 +423,7 @@ static void ParseCpuId(const Leaves* leaves, X86Info* info,
       features->avx = IsBitSet(leaf_1.ecx, 28);
       features->avx_vnni = IsBitSet(leaf_7_1.eax, 4);
       features->avx2 = IsBitSet(leaf_7.ebx, 5);
+      features->avxifma = IsBitSet(leaf_7_1.eax, 23);
     }
     if (os_preserves->avx512_registers) {
       features->avx512f = IsBitSet(leaf_7.ebx, 16);
@@ -1954,6 +1955,7 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(X86_AVX, avx, , , )                                 \
   LINE(X86_AVX_VNNI, avx_vnni, , , )                       \
   LINE(X86_AVX2, avx2, , , )                               \
+  LINE(X86_AVXIFMA, avxifma, , , )                         \
   LINE(X86_AVX512F, avx512f, , , )                         \
   LINE(X86_AVX512CD, avx512cd, , , )                       \
   LINE(X86_AVX512ER, avx512er, , , )                       \


### PR DESCRIPTION
Add avx-ifma detection according to the https://en.wikipedia.org/wiki/CPUID#EAX=7,_ECX=1:_Extended_Features.