### PR TITLE
fixed bug for windows-arm64 (introduced in pull request #291)

### DIFF
--- a/src/define_introspection.inl
+++ b/src/define_introspection.inl
@@ -71,6 +71,7 @@ static void (*const kSetters[])(FEAT_TYPE_NAME*, bool) = {INTROSPECTION_TABLE};
 // Implements the `GetXXXFeaturesEnumValue` API.
 int GET_FEAT_ENUM_VALUE(const FEAT_TYPE_NAME* features, FEAT_ENUM_NAME value) {
   if (value >= FEAT_ENUM_LAST) return false;
+  if (value >= sizeof(kGetters)/sizeof(kGetters[0])) return false;
   return kGetters[value](features);
 }
 
@@ -82,5 +83,6 @@ static const char* kFeatureNames[] = {INTROSPECTION_TABLE};
 // Implements the `GetXXXFeaturesEnumName` API.
 const char* GET_FEAT_ENUM_NAME(FEAT_ENUM_NAME value) {
   if (value >= FEAT_ENUM_LAST) return "unknown_feature";
+  if (value >= sizeof(kFeatureNames)/sizeof(kFeatureNames[0])) return "unknown_feature";
   return kFeatureNames[value];
 }


### PR DESCRIPTION
https://github.com/google/cpu_features/pull/291 introduced shorter INTROSPECTION_TABLE in impl_aarch64_windows.c so while public headers declare AARCH64_LAST_=78 only 54 entries were inited in kGetters kFeatureNames.
Thus iterating all features upto AARCH64_LAST_ caused crash as long as garbage pointer at kGetters[54] was called.
Current implementation seems very unsafe and in order to prevent crash we should check for kGetters array size (that corresponds to INTROSPECTION_TABLE entries). Another solution is static assert for AARCH64_LAST_  == sizeof(kGetters).