### PR TITLE
Fix cmake error CMP0057

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 
+# see: https://cmake.org/cmake/help/latest/policy/CMP0057.html
+cmake_policy(SET CMP0057 NEW)
+
 # option() honors normal variables.
 # see: https://cmake.org/cmake/help/git-stage/policy/CMP0077.html
 if(POLICY CMP0077)


### PR DESCRIPTION
Compiling with Android NDK 27 failed with the following error:


```
-- The C compiler identification is Clang 18.0.1
CMake Warning (dev) at /home/user/Android/Sdk/ndk/android-ndk-r27/build/cmake/flags.cmake:46 (if):
  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  IN_LIST will be interpreted as an operator when the policy is set to NEW.
  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  /home/user/Android/Sdk/cmake/3.22.1/share/cmake-3.22/Modules/Platform/Android-Clang.cmake:23 (include)
  /home/user/Android/Sdk/cmake/3.22.1/share/cmake-3.22/Modules/Platform/Android-Clang-C.cmake:1 (include)
  /home/user/Android/Sdk/cmake/3.22.1/share/cmake-3.22/Modules/CMakeCInformation.cmake:48 (include)
  CMakeLists.txt:9 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at /home/user/Android/Sdk/ndk/android-ndk-r27/build/cmake/flags.cmake:46 (if):
  if given arguments:

    "hwaddress" "IN_LIST" "ANDROID_SANITIZE"

  Unknown arguments specified
Call Stack (most recent call first):
  /home/user/Android/Sdk/cmake/3.22.1/share/cmake-3.22/Modules/Platform/Android-Clang.cmake:23 (include)
  /home/user/Android/Sdk/cmake/3.22.1/share/cmake-3.22/Modules/Platform/Android-Clang-C.cmake:1 (include)
  /home/user/Android/Sdk/cmake/3.22.1/share/cmake-3.22/Modules/CMakeCInformation.cmake:48 (include)
  CMakeLists.txt:9 (project)

```
(Still compiled successfully with NDK 25)


NDK 27 error is now fixed with:
`cmake_policy(SET CMP0057 NEW)`