### PR TITLE
Update amd64 macos workflow to use X86 arch

### DIFF
--- a/.github/workflows/amd64_macos_bazel.yml
+++ b/.github/workflows/amd64_macos_bazel.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # Building using the github runner environement directly.
   bazel:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/amd64_macos_bazel.yml
+++ b/.github/workflows/amd64_macos_bazel.yml
@@ -1,3 +1,4 @@
+# ref: https://github.com/actions/runner-images
 name: amd64 MacOS Bazel
 
 on:
@@ -10,7 +11,7 @@ on:
 jobs:
   # Building using the github runner environement directly.
   bazel:
-    runs-on: macos-13
+    runs-on: macos-13 # Using x86 processors, ref: https://github.com/actions/runner-images
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/amd64_macos_cmake.yml
+++ b/.github/workflows/amd64_macos_cmake.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # Building using the github runner environement directly.
   xcode:
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:

--- a/.github/workflows/amd64_macos_cmake.yml
+++ b/.github/workflows/amd64_macos_cmake.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install
       run: cmake --build build --config Release --target install -v
   make:
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:

--- a/.github/workflows/amd64_macos_cmake.yml
+++ b/.github/workflows/amd64_macos_cmake.yml
@@ -1,3 +1,4 @@
+# ref: https://github.com/actions/runner-images
 name: amd64 MacOS CMake
 
 on:
@@ -10,7 +11,7 @@ on:
 jobs:
   # Building using the github runner environement directly.
   xcode:
-    runs-on: macos-13
+    runs-on: macos-13 # Using x86 processors, ref: https://github.com/actions/runner-images
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:
@@ -26,7 +27,7 @@ jobs:
     - name: Install
       run: cmake --build build --config Release --target install -v
   make:
-    runs-on: macos-13
+    runs-on: macos-13 # Using x86 processors, ref: https://github.com/actions/runner-images
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:


### PR DESCRIPTION
Github Actions added support M1, thus macOS supports arm64 and amd64 in actions:
* `macos-latest` is arm64 architecture
* `macos-13` is amd64 architecture 

see details:
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners

it looks like `macos-latest-large` is not supported to use amd64
https://github.com/actions/runner-images?tab=readme-ov-file#available-images

Also, we should add CI/CD arm64 architecture support for macOS M1 CPUs in the separate patch and fix tests.
See details: https://github.com/google/cpu_features/actions/runs/10499466482/job/29086289583

```shell
Running main() from gmock_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from CpuidAarch64Test
[ RUN      ] CpuidAarch64Test.Aarch64FeaturesEnum
[       OK ] CpuidAarch64Test.Aarch64FeaturesEnum (0 ms)
[ RUN      ] CpuidAarch64Test.FromDarwinSysctlFromName
test/cpuinfo_aarch64_test.cc:341: Failure
Expected equality of these values:
  info.part
    Which is: 0
  0x1B588BB3
    Which is: 458787763
test/cpuinfo_aarch64_test.cc:342: Failure
Expected equality of these values:
  info.revision
    Which is: 0
  2
test/cpuinfo_aarch64_test.cc:345: Failure
Value of: info.features.asimd
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:347: Failure
Value of: info.features.aes
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:348: Failure
Value of: info.features.pmull
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:349: Failure
Value of: info.features.sha1
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:350: Failure
Value of: info.features.sha2
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:356: Failure
Value of: info.features.asimdrdm
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:357: Failure
Value of: info.features.jscvt
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:358: Failure
Value of: info.features.fcma
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:359: Failure
Value of: info.features.lrcpc
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:360: Failure
Value of: info.features.dcpop
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:364: Failure
Value of: info.features.asimddp
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:368: Failure
Value of: info.features.dit
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:369: Failure
Value of: info.features.uscat
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:371: Failure
Value of: info.features.flagm
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:372: Failure
Value of: info.features.ssbs
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:373: Failure
Value of: info.features.sb
  Actual: true
Expected: false
[  FAILED  ] CpuidAarch64Test.FromDarwinSysctlFromName (0 ms)
[----------] 2 tests from CpuidAarch64Test (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] CpuidAarch64Test.FromDarwinSysctlFromName

 1 FAILED TEST
================================================================================
INFO: Found [15](https://github.com/google/cpu_features/actions/runs/10499466482/job/29086289583#step:6:16) targets and 4 test targets...
INFO: Elapsed time: 0.415s, Critical Path: 0.17s
INFO: 5 processes: 1 internal, 4 darwin-sandbox.
INFO: Build completed, 1 test FAILED, 5 total actions
//:bit_utils_test                                                        PASSED in 0.1s
//:stack_line_reader_test                                                PASSED in 0.1s
//:string_view_test                                                      PASSED in 0.1s
//:cpuinfo_test                                                          FAILED in 0.0s
  /private/var/tmp/_bazel_runner/95[28](https://github.com/google/cpu_features/actions/runs/10499466482/job/29086289583#step:6:29)e8115d3e1528a3dc7979ba042b2f/execroot/_main/bazel-out/darwin_arm64-opt/testlogs/cpuinfo_test/test.log

Executed 4 out of 4 tests: 3 tests pass and 1 fails locally.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```