### PR TITLE
Fix run_integration.sh

### DIFF
--- a/cmake/ci/docker/amd64/Dockerfile
+++ b/cmake/ci/docker/amd64/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="corentinl@google.com"
 ENV PATH=/usr/local/bin:$PATH
 RUN apt-get update -qq \
 && DEBIAN_FRONTEND=noninteractive apt-get install -yq git wget libssl-dev build-essential \
- ninja-build python3 pkgconf libglib2.0-dev \
+ ninja-build python3 python3-venv pkgconf libglib2.0-dev \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ENTRYPOINT ["/usr/bin/bash", "-c"]

--- a/cmake/ci/docker/toolchain/Dockerfile
+++ b/cmake/ci/docker/toolchain/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="corentinl@google.com"
 ENV PATH=/usr/local/bin:$PATH
 RUN apt-get update -qq \
 && DEBIAN_FRONTEND=noninteractive apt-get install -yq git wget libssl-dev build-essential \
- ninja-build python3 pkgconf libglib2.0-dev \
+ ninja-build python3 python3-venv pkgconf libglib2.0-dev \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ENTRYPOINT ["/usr/bin/bash", "-c"]

--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -33,7 +33,7 @@ function install_qemu() {
     >&2 echo 'QEMU is disabled !'
     return 0
   fi
-  local -r QEMU_VERSION=${QEMU_VERSION:=7.1.0}
+  local -r QEMU_VERSION=${QEMU_VERSION:=9.0.2}
   local -r QEMU_TARGET=${QEMU_ARCH}-linux-user
 
   if echo "${QEMU_VERSION} ${QEMU_TARGET}" | cmp --silent "${QEMU_INSTALL}/.build" -; then

--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -47,7 +47,7 @@ function install_qemu() {
   rm -rf "${QEMU_INSTALL}"
 
   # Checking for a tarball before downloading makes testing easier :-)
-  local -r QEMU_URL="http://wiki.qemu-project.org/download/qemu-${QEMU_VERSION}.tar.xz"
+  local -r QEMU_URL="https://download.qemu.org/qemu-${QEMU_VERSION}.tar.xz"
   local -r QEMU_DIR="qemu-${QEMU_VERSION}"
   unpack ${QEMU_URL} ${QEMU_DIR}
   cd ${QEMU_DIR} || exit 2


### PR DESCRIPTION
* Updated deprecated qemu-download url to new https://download.qemu.org/
* Updated QEMU version from 7.1.0 to 9.0.2 (latest)
* Fixed error `Python's ensurepip module is not found.`

Proof of success:
* powerpc: https://github.com/toor1245/cpu_features/actions/runs/10550675548
* mips: https://github.com/toor1245/cpu_features/actions/runs/10550675550