### PR TITLE
Fix bazel build testing for macos arm64

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -322,6 +322,10 @@ cc_library(
     copts = C99_FLAGS,
     defines = selects.with_or({
         PLATFORM_CPU_X86_64: ["CPU_FEATURES_MOCK_CPUID_X86"],
+	PLATFORM_CPU_ARM64: [
+	    "CPU_FEATURES_MOCK_CPUID_AARCH64",
+	    "CPU_FEATURES_MOCK_SYSCTL_AARCH64",
+	],
         "//conditions:default": [],
     }) + selects.with_or({
         PLATFORM_OS_MACOS: ["HAVE_SYSCTLBYNAME"],


### PR DESCRIPTION
We don't have mock compilation definitions for bazel, so our tests will get real CPU information and the tests will fail:
https://github.com/toor1245/cpu_features/actions/runs/10551510292/job/29229039421#step:6:23

```
FAIL: //:cpuinfo_test (see /private/var/tmp/_bazel_runner/9528e8115d3e1528a3dc7979ba042b2f/execroot/_main/bazel-out/darwin_arm64-opt/testlogs/cpuinfo_test/test.log)
==================== Test output for //:cpuinfo_test:
INFO: From Testing //:cpuinfo_test:
Running main() from gmock_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from CpuidAarch64Test
[ RUN      ] CpuidAarch64Test.Aarch64FeaturesEnum
[       OK ] CpuidAarch64Test.Aarch64FeaturesEnum (0 ms)
[ RUN      ] CpuidAarch64Test.FromDarwinSysctlFromName
test/cpuinfo_aarch64_test.cc:341: Failure
Expected equality of these values:
  info.part
    Which is: 0
  0x1B588BB3
    Which is: 458787763
test/cpuinfo_aarch64_test.cc:342: Failure
Expected equality of these values:
  info.revision
    Which is: 0
  2
test/cpuinfo_aarch64_test.cc:345: Failure
Value of: info.features.asimd
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:347: Failure
Value of: info.features.aes
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:348: Failure
Value of: info.features.pmull
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:349: Failure
Value of: info.features.sha1
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:350: Failure
Value of: info.features.sha2
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:356: Failure
Value of: info.features.asimdrdm
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:357: Failure
Value of: info.features.jscvt
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:358: Failure
Value of: info.features.fcma
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:359: Failure
Value of: info.features.lrcpc
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:360: Failure
Value of: info.features.dcpop
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:364: Failure
Value of: info.features.asimddp
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:368: Failure
Value of: info.features.dit
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:369: Failure
Value of: info.features.uscat
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:371: Failure
Value of: info.features.flagm
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:372: Failure
Value of: info.features.ssbs
  Actual: true
Expected: false
test/cpuinfo_aarch64_test.cc:373: Failure
Value of: info.features.sb
  Actual: true
Expected: false
[  FAILED  ] CpuidAarch64Test.FromDarwinSysctlFromName (0 ms)
[----------] 2 tests from CpuidAarch64Test (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] CpuidAarch64Test.FromDarwinSysctlFromName

 1 FAILED TEST
================================================================================
INFO: Found [15](https://github.com/toor1245/cpu_features/actions/runs/10552152982/job/29230573488?pr=4#step:6:16) targets and 4 test targets...
INFO: Elapsed time: 0.584s, Critical Path: 0.25s
INFO: 5 processes: 1 internal, 4 darwin-sandbox.
INFO: Build completed, 1 test FAILED, 5 total actions
//:bit_utils_test                                                        PASSED in 0.1s
//:stack_line_reader_test                                                PASSED in 0.1s
//:string_view_test                                                      PASSED in 0.1s
//:cpuinfo_test                                                          FAILED in 0.2s
  /private/var/tmp/_bazel_runner/95[28](https://github.com/toor1245/cpu_features/actions/runs/10552152982/job/29230573488?pr=4#step:6:29)e8115d3e1528a3dc7979ba042b2f/execroot/_main/bazel-out/darwin_arm64-opt/testlogs/cpuinfo_test/test.log
```

Proof of success:
https://github.com/toor1245/cpu_features/actions/runs/10552152982/job/29230573488?pr=4#step:6:1