### PR TITLE
Fix wrong arm neon detection

### DIFF
--- a/include/cpu_features_macros.h
+++ b/include/cpu_features_macros.h
@@ -235,11 +235,11 @@
 #endif  // defined(CPU_FEATURES_ARCH_X86)
 
 #if defined(CPU_FEATURES_ARCH_ANY_ARM)
-#if defined(__ARM_NEON__)
+#if defined(__ARM_NEON)
 #define CPU_FEATURES_COMPILED_ANY_ARM_NEON 1
 #else
 #define CPU_FEATURES_COMPILED_ANY_ARM_NEON 0
-#endif  //  defined(__ARM_NEON__)
+#endif  //  defined(__ARM_NEON)
 #endif  //  defined(CPU_FEATURES_ARCH_ANY_ARM)
 
 #if defined(CPU_FEATURES_ARCH_MIPS)


### PR DESCRIPTION
ARM Architecture Reference Manual suggests to check for the presence of the Advanced SIMD instructions via `__ARM_NEON`