### PR TITLE
FreeBSD CI support

### DIFF
--- a/.github/workflows/amd64_freebsd_cmake.yml
+++ b/.github/workflows/amd64_freebsd_cmake.yml
@@ -1,0 +1,31 @@
+name: amd64 FreeBSD CMake
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # min hours day(month) month day(week)
+    - cron: '0 0 7,22 * *'
+
+jobs:
+  make:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run tests
+        uses: cross-platform-actions/action@v0.25.0
+        with:
+          operating_system: freebsd
+          architecture: x86-64
+          version: '14.1'
+          shell: bash
+          memory: 5G
+          cpu_count: 4
+          run: |
+            sudo pkg install -y cmake git
+            sudo cmake --version
+            sudo cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
+            sudo cmake --build build --target all -v
+            sudo cmake --build build --target test -v
+            sudo cmake --build build --target install -v
+           

--- a/.github/workflows/arm64_freebsd_cmake.yml
+++ b/.github/workflows/arm64_freebsd_cmake.yml
@@ -1,0 +1,31 @@
+name: Arm64 FreeBSD CMake
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # min hours day(month) month day(week)
+    - cron: '0 0 7,22 * *'
+
+jobs:
+  make:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and run tests
+        uses: cross-platform-actions/action@v0.25.0
+        with:
+          operating_system: freebsd
+          architecture: arm64
+          version: '14.1'
+          shell: bash
+          memory: 5G
+          cpu_count: 4
+          run: |
+            sudo pkg install -y cmake git
+            sudo cmake --version
+            sudo cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
+            sudo cmake --build build --target all -v
+            sudo cmake --build build --target test -v
+            sudo cmake --build build --target install -v
+           


### PR DESCRIPTION
Checked another solutions to support FreeBSD CI:
* freebsd-vm: https://github.com/vmactions/freebsd-vm
* cross-platform-actions: https://github.com/cross-platform-actions/action

### freebsd-vm:
It looks like this solution supports only amd64 architecture
https://github.com/vmactions/freebsd-builder/blob/main/conf/freebsd-14.1.conf#L3

However, in builder script there is `VM_ARCH`
https://github.com/vmactions/freebsd-builder/blob/f799d8fb9b84977ec8fa020178262de39eaa4b83/build.sh#L35

and [upcoming features](https://github.com/vmactions/freebsd-vm?tab=readme-ov-file#upcoming-features):
* Runs on MacOS to use cpu accelaration.
* Support ARM and other architecture.

Maybe it’s possible manually configure the architecture somehow, but at the moment it looks like a hardcoded architecture amd64

### cross-platform-actions:

This action supports FreeBSD `amd64` and `arm64` architectures and we support these architectures for FreeBSD:
https://github.com/cross-platform-actions/action?tab=readme-ov-file#freebsd-freebsd

I used this solution, proof of success:
* FreeBSD amd64: https://github.com/toor1245/cpu_features/actions/runs/10652248435/job/29525815775#step:3:556
* FreeBSD arm64: https://github.com/toor1245/cpu_features/actions/runs/10652474246/job/29526357627#step:3:568