### PR TITLE
Fix: Windows does not define __ARM_NEON

### DIFF
--- a/include/cpu_features_macros.h
+++ b/include/cpu_features_macros.h
@@ -234,13 +234,14 @@
 
 #endif  // defined(CPU_FEATURES_ARCH_X86)
 
-// Note: MSVC targeting ARM does not define `__ARM_NEON` but Windows on ARM requires it.
-// In that case we force NEON detection.
-#if defined(__ARM_NEON) || (defined(CPU_FEATURES_COMPILER_MSC) && defined(CPU_FEATURES_ARCH_ANY_ARM))
+// Note: MSVC targeting ARM does not define `__ARM_NEON` but Windows on ARM
+// requires it. In that case we force NEON detection.
+#if defined(__ARM_NEON) || \
+    (defined(CPU_FEATURES_COMPILER_MSC) && defined(CPU_FEATURES_ARCH_ANY_ARM))
 #define CPU_FEATURES_COMPILED_ANY_ARM_NEON 1
 #else
 #define CPU_FEATURES_COMPILED_ANY_ARM_NEON 0
-#endif // defined(__ARM_NEON) || (defined(CPU_FEATURES_COMPILER_MSC) && defined(CPU_FEATURES_ARCH_ANY_ARM))
+#endif
 
 #if defined(CPU_FEATURES_ARCH_MIPS)
 #if defined(__mips_msa)

--- a/include/cpu_features_macros.h
+++ b/include/cpu_features_macros.h
@@ -235,7 +235,7 @@
 #endif  // defined(CPU_FEATURES_ARCH_X86)
 
 #if defined(CPU_FEATURES_ARCH_ANY_ARM)
-#if defined(__ARM_NEON)
+#if defined(__ARM_NEON) || defined(_MSC_VER)
 #define CPU_FEATURES_COMPILED_ANY_ARM_NEON 1
 #else
 #define CPU_FEATURES_COMPILED_ANY_ARM_NEON 0

--- a/include/cpu_features_macros.h
+++ b/include/cpu_features_macros.h
@@ -234,13 +234,13 @@
 
 #endif  // defined(CPU_FEATURES_ARCH_X86)
 
-#if defined(CPU_FEATURES_ARCH_ANY_ARM)
-#if defined(__ARM_NEON) || defined(_MSC_VER)
+// Note: MSVC targeting ARM does not define `__ARM_NEON` but Windows on ARM requires it.
+// In that case we force NEON detection.
+#if defined(__ARM_NEON) || (defined(CPU_FEATURES_COMPILER_MSC) && defined(CPU_FEATURES_ARCH_ANY_ARM))
 #define CPU_FEATURES_COMPILED_ANY_ARM_NEON 1
 #else
 #define CPU_FEATURES_COMPILED_ANY_ARM_NEON 0
-#endif  //  defined(__ARM_NEON)
-#endif  //  defined(CPU_FEATURES_ARCH_ANY_ARM)
+#endif // defined(__ARM_NEON) || (defined(CPU_FEATURES_COMPILER_MSC) && defined(CPU_FEATURES_ARCH_ANY_ARM))
 
 #if defined(CPU_FEATURES_ARCH_MIPS)
 #if defined(__mips_msa)


### PR DESCRIPTION
On MSVC for ARM/ARM64, __ARM_NEON is not defined. However, Windows requires NEON on ARM, so it should be safe to assume that if CPU_FEATURES_ARCH_ANY_ARM is defined and we're in MSVC, NEON is also available.

There may be a better way to do this, but this patch has helped get my project running at full speed on Windows ARM64 machines and wanted to share. Thanks for this great library!