### PR TITLE
Move `c99` flag from BUILD file to bazel cmd line

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,9 +3,6 @@
 # Use sparingly for things common to all compilers and platforms.
 ###############################################################################
 
-# Enable Bzlmod for every Bazel command
-common --enable_bzlmod
-
 # Prevent invalid caching if input files are modified during a build.
 build --experimental_guard_against_concurrent_changes
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,35 @@
+###############################################################################
+# Common flags that apply to all configurations.
+# Use sparingly for things common to all compilers and platforms.
+###############################################################################
+
+# Enable Bzlmod for every Bazel command
+common --enable_bzlmod
+
+# Prevent invalid caching if input files are modified during a build.
+build --experimental_guard_against_concurrent_changes
+
+###############################################################################
+# Options for continuous integration.
+###############################################################################
+
+# Speedup bazel using a ramdisk.
+build:ci --sandbox_base=/dev/shm
+
+# Show as many errors as possible.
+build:ci --keep_going
+
+# Show subcommands when building
+build:ci --subcommands=true 
+
+# Make sure we test for C99 compliance when building the library
+build:ci --conlyopt=-std=c99
+
+# Show test errors.
+test:ci --test_output=errors
+
+###############################################################################
+
+# The user.bazelrc file is not checked in but available for local mods.
+# Always keep this at the end of the file so that user flags override.
+try-import %workspace%/user.bazelrc

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,7 +14,6 @@ exports_files(["LICENSE"])
 INCLUDES = ["include"]
 
 C99_FLAGS = [
-    "-std=c99",
     "-Wall",
     "-Wextra",
     "-Wmissing-declarations",

--- a/bazel/ci/docker/Dockerfile
+++ b/bazel/ci/docker/Dockerfile
@@ -25,13 +25,7 @@ COPY . .
 
 FROM devel AS build
 RUN bazel version
-RUN bazel build \
- -c opt \
- --subcommands=true \
- ...
+RUN bazel build --config=ci ...
 
 FROM build AS test
-RUN bazel test \
- -c opt \
- --test_output=errors \
- ...
+RUN bazel test  --config=ci ...


### PR DESCRIPTION
Requiring c99 for everyone breaks downstream users.
