### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/aarch64_linux_bazel.yml
+++ b/.github/workflows/aarch64_linux_bazel.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Check docker

--- a/.github/workflows/aarch64_linux_cmake.yml
+++ b/.github/workflows/aarch64_linux_cmake.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       TARGET: ${{ matrix.targets[0] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: make --directory=cmake/ci ${TARGET}_build
     - name: Test

--- a/.github/workflows/amd64_freebsd_cmake.yml_disabled
+++ b/.github/workflows/amd64_freebsd_cmake.yml_disabled
@@ -13,7 +13,7 @@ jobs:
   make:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: vagrant version
       run: Vagrant --version
     - name: VirtualBox version

--- a/.github/workflows/amd64_linux_bazel.yml
+++ b/.github/workflows/amd64_linux_bazel.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Check docker

--- a/.github/workflows/amd64_linux_cmake.yml
+++ b/.github/workflows/amd64_linux_cmake.yml
@@ -12,7 +12,7 @@ jobs:
   make:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Env
       run: make --directory=cmake/ci amd64_env
     - name: Devel

--- a/.github/workflows/amd64_macos_bazel.yml
+++ b/.github/workflows/amd64_macos_bazel.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-13 # Using x86 processors, ref: https://github.com/actions/runner-images
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Bazel
         run: |
           brew update

--- a/.github/workflows/amd64_macos_cmake.yml
+++ b/.github/workflows/amd64_macos_cmake.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Check cmake
       run: cmake --version
     - name: Configure
@@ -31,7 +31,7 @@ jobs:
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Check cmake
       run: cmake --version
     - name: Configure

--- a/.github/workflows/amd64_windows_cmake.yml
+++ b/.github/workflows/amd64_windows_cmake.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Configure
       run: cmake -S. -Bbuild -G "Visual Studio 17 2022" -DCMAKE_CONFIGURATION_TYPES=Release
     - name: Build

--- a/.github/workflows/arm64_macos_bazel.yml
+++ b/.github/workflows/arm64_macos_bazel.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest # Using M1 processors, ref: https://github.com/actions/runner-images
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Bazel
         run: |
           brew update

--- a/.github/workflows/arm64_macos_cmake.yml
+++ b/.github/workflows/arm64_macos_cmake.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Check cmake
       run: cmake --version
     - name: Configure
@@ -31,7 +31,7 @@ jobs:
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Check cmake
       run: cmake --version
     - name: Configure

--- a/.github/workflows/arm_linux_cmake.yml
+++ b/.github/workflows/arm_linux_cmake.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       TARGET: ${{ matrix.targets[0] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: make --directory=cmake/ci ${TARGET}_build
     - name: Test

--- a/.github/workflows/mips_linux_cmake.yml
+++ b/.github/workflows/mips_linux_cmake.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       TARGET: ${{ matrix.targets[0] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: make --directory=cmake/ci ${TARGET}_build
     - name: Test

--- a/.github/workflows/power_linux_cmake.yml
+++ b/.github/workflows/power_linux_cmake.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       TARGET: ${{ matrix.targets[0] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: make --directory=cmake/ci ${TARGET}_build
     - name: Test

--- a/.github/workflows/riscv_linux_cmake.yml
+++ b/.github/workflows/riscv_linux_cmake.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       TARGET: ${{ matrix.targets[0] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: make --directory=cmake/ci ${TARGET}_build
     - name: Test

--- a/.github/workflows/s390x_linux_cmake.yml
+++ b/.github/workflows/s390x_linux_cmake.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       TARGET: ${{ matrix.targets[0] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: make --directory=cmake/ci ${TARGET}_build
     - name: Test


### PR DESCRIPTION
Resolves node.js deprecation warnings in Actions

`The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2`
`The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v2`
`The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3`