### PR TITLE
cmake: Remove useless check for CMP0077

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
 
-# option() honors normal variables.
-# see: https://cmake.org/cmake/help/git-stage/policy/CMP0077.html
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
 project(CpuFeatures VERSION 0.9.0 LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
cpu_features requires CMake 3.13 which sets CMP0077 always to NEW.