### PR TITLE
Fix allocator bump in printf string allocation

### DIFF
--- a/src/utils/list_cpu_features.c
+++ b/src/utils/list_cpu_features.c
@@ -148,7 +148,11 @@ static Node* CreatePrintfString(const char* format, ...) {
   const int written = vsnprintf(ptr, gBumpAllocator.size, format, arglist);
   va_end(arglist);
   if (written < 0 || written >= (int)gBumpAllocator.size) internal_error();
-  return CreateConstantString((char*)BA_Bump(written));
+  // `vsnprintf` does not set `\0` when no characters are to be written.
+  if (written == 0) *ptr = '\0';
+  // `vsnprintf` returns the number of printed characters excluding `\0`.
+  const int null_terminated_written = written + 1;
+  return CreateConstantString((char*)BA_Bump(null_terminated_written));
 }
 
 // Adds a string node.


### PR DESCRIPTION
`vsnprintf` returns the number of printed characters _excluding_ the written `\0`. This leads to the next value overwriting the last `\0`, which in turn can print spurious characters to the output.

Fixes #373.
