### PR TITLE
[bazel] Add missing platform dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,3 +15,4 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "googletest", version = "1.15.2")
+bazel_dep(name = "platforms", version = "0.0.10")


### PR DESCRIPTION
This is required with Bazel 8 that drops the support for WORKSPACE file.
