### PR TITLE
Fix ci

### DIFF
--- a/cmake/ci/Makefile
+++ b/cmake/ci/Makefile
@@ -155,7 +155,8 @@ TOOLCHAIN_TARGETS = \
  arm-linux-gnueabihf armv8l-linux-gnueabihf arm-linux-gnueabi armeb-linux-gnueabihf armeb-linux-gnueabi \
  aarch64-linux-gnu aarch64_be-linux-gnu \
  mips32 mips32el mips64 mips64el \
- ppc ppc64 ppc64le \
+ ppc ppc-440fp ppc-e500mc \
+ ppc64 ppc64le \
  riscv32 riscv64 \
  s390x
 TOOLCHAIN_STAGES = env devel build test

--- a/cmake/ci/docker/toolchain/Dockerfile
+++ b/cmake/ci/docker/toolchain/Dockerfile
@@ -5,25 +5,22 @@ LABEL maintainer="corentinl@google.com"
 # Install system build dependencies
 ENV PATH=/usr/local/bin:$PATH
 RUN apt-get update -qq \
-&& DEBIAN_FRONTEND=noninteractive apt-get install -yq git wget libssl-dev build-essential \
- ninja-build python3 python3-venv pkgconf libglib2.0-dev \
+&& DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+ git wget libssl-dev \
+ build-essential cmake ninja-build \
+ python3 python3-venv \
+ pkgconf libglib2.0-dev \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ENTRYPOINT ["/usr/bin/bash", "-c"]
 CMD ["/usr/bin/bash"]
-
-# Install CMake 3.21.3
-RUN wget "https://cmake.org/files/v3.21/cmake-3.21.3-linux-x86_64.sh" \
-&& chmod a+x cmake-3.21.3-linux-x86_64.sh \
-&& ./cmake-3.21.3-linux-x86_64.sh --prefix=/usr/local/ --skip-license \
-&& rm cmake-3.21.3-linux-x86_64.sh
 
 FROM env AS devel
 WORKDIR /home/project
 COPY . .
 
 ARG TARGET
-ENV TARGET ${TARGET:-unknown}
+ENV TARGET=${TARGET:-unknown}
 
 FROM devel AS build
 RUN cmake -version

--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -33,7 +33,7 @@ function install_qemu() {
     >&2 echo 'QEMU is disabled !'
     return 0
   fi
-  local -r QEMU_VERSION=${QEMU_VERSION:=9.0.2}
+  local -r QEMU_VERSION=${QEMU_VERSION:=9.0.4}
   local -r QEMU_TARGET=${QEMU_ARCH}-linux-user
 
   if echo "${QEMU_VERSION} ${QEMU_TARGET}" | cmp --silent "${QEMU_INSTALL}/.build" -; then
@@ -49,8 +49,8 @@ function install_qemu() {
   # Checking for a tarball before downloading makes testing easier :-)
   local -r QEMU_URL="https://download.qemu.org/qemu-${QEMU_VERSION}.tar.xz"
   local -r QEMU_DIR="qemu-${QEMU_VERSION}"
-  unpack ${QEMU_URL} ${QEMU_DIR}
-  cd ${QEMU_DIR} || exit 2
+  unpack "${QEMU_URL}" "${QEMU_DIR}"
+  cd "${QEMU_DIR}" || exit 2
 
   # Qemu (meson based build) depends on: pkgconf, libglib2.0, python3, ninja
   ./configure \

--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -165,6 +165,7 @@ function expand_bootlin_config() {
       local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-440fp/tarballs/powerpc-440fp--glibc--stable-2024.05-1.tar.xz"
       local -r GCC_PREFIX="powerpc"
       local -r GCC_SUFFIX=""
+      QEMU_ARGS+=( -cpu "440epx" )
       ;;
     "ppc-e500mc")
       local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-e500mc/tarballs/powerpc-e500mc--glibc--stable-2024.05-1.tar.xz"

--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -141,38 +141,61 @@ function expand_bootlin_config() {
   local -r GCC_DIR=${ARCHIVE_DIR}/${GCC_RELATIVE_DIR}
 
   case "${TARGET}" in
-    "aarch64")
-      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/aarch64--glibc--stable-2021.11-1.tar.bz2"
+    "arm" | "armv7-eabihf")
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/armv7-eabihf--glibc--stable-2024.05-1.tar.xz"
+      local -r GCC_PREFIX="arm"
+      local -r GCC_SUFFIX="eabihf"
+      ;;
+    "armeb" | "armebv7-eabihf")
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/armebv7-eabihf/tarballs/armebv7-eabihf--glibc--stable-2024.05-1.tar.xz"
+      local -r GCC_PREFIX="armeb"
+      local -r GCC_SUFFIX="eabihf"
+      ;;
+    "arm64" | "aarch64")
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/aarch64--glibc--stable-2024.05-1.tar.xz"
       local -r GCC_PREFIX="aarch64"
+      local -r GCC_SUFFIX=""
       ;;
-    "aarch64be")
-      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64be/tarballs/aarch64be--glibc--stable-2021.11-1.tar.bz2"
+    "arm64be" | "aarch64be")
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64be/tarballs/aarch64be--glibc--stable-2024.05-1.tar.xz"
       local -r GCC_PREFIX="aarch64_be"
+      local -r GCC_SUFFIX=""
       ;;
-    "ppc64le")
-      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc64le-power8/tarballs/powerpc64le-power8--glibc--stable-2021.11-1.tar.bz2"
-      local -r GCC_PREFIX="powerpc64le"
-      ;;
-    "ppc64")
-      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc64-power8/tarballs/powerpc64-power8--glibc--stable-2021.11-1.tar.bz2"
-      local -r GCC_PREFIX="powerpc64"
-      ;;
-    "ppc")
-      #local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-e500mc/tarballs/powerpc-e500mc--glibc--stable-2021.11-1.tar.bz2"
-      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-440fp/tarballs/powerpc-440fp--glibc--stable-2021.11-1.tar.bz2"
+    "ppc" | "ppc-440fp")
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-440fp/tarballs/powerpc-440fp--glibc--stable-2024.05-1.tar.xz"
       local -r GCC_PREFIX="powerpc"
+      local -r GCC_SUFFIX=""
+      ;;
+    "ppc-e500mc")
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc-e500mc/tarballs/powerpc-e500mc--glibc--stable-2024.05-1.tar.xz"
+      local -r GCC_PREFIX="powerpc"
+      local -r GCC_SUFFIX=""
+      QEMU_ARGS+=( -cpu "e500mc" )
+      ;;
+    "ppc64" | "ppc64-power8")
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc64-power8/tarballs/powerpc64-power8--glibc--stable-2024.05-1.tar.xz"
+      local -r GCC_PREFIX="powerpc64"
+      local -r GCC_SUFFIX=""
+      ;;
+    "ppc64le" | "ppc64le-power8")
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/powerpc64le-power8/tarballs/powerpc64le-power8--glibc--stable-2024.05-1.tar.xz"
+      local -r GCC_PREFIX="powerpc64le"
+      local -r GCC_SUFFIX=""
       ;;
     "riscv32")
-      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/riscv32-ilp32d/tarballs/riscv32-ilp32d--glibc--bleeding-edge-2022.08-1.tar.bz2"
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/riscv32-ilp32d/tarballs/riscv32-ilp32d--glibc--bleeding-edge-2024.05-1.tar.xz"
       local -r GCC_PREFIX="riscv32"
+      local -r GCC_SUFFIX=""
       ;;
     "riscv64")
-      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/riscv64-lp64d/tarballs/riscv64-lp64d--glibc--stable-2022.08-1.tar.bz2"
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/riscv64-lp64d/tarballs/riscv64-lp64d--glibc--stable-2024.05-1.tar.xz"
       local -r GCC_PREFIX="riscv64"
+      local -r GCC_SUFFIX=""
       ;;
     "s390x")
-      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/s390x-z13/tarballs/s390x-z13--glibc--stable-2022.08-1.tar.bz2"
+      local -r TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/s390x-z13/tarballs/s390x-z13--glibc--stable-2024.05-1.tar.xz"
       local -r GCC_PREFIX="s390x"
+      local -r GCC_SUFFIX=""
       ;;
     *)
       >&2 echo 'unknown power platform'
@@ -181,14 +204,14 @@ function expand_bootlin_config() {
 
   local -r TOOLCHAIN_RELATIVE_DIR="${TARGET}"
   unpack "${TOOLCHAIN_URL}" "${TOOLCHAIN_RELATIVE_DIR}"
-  local -r EXTRACT_DIR="${ARCHIVE_DIR}/$(basename ${TOOLCHAIN_URL%.tar.bz2})"
+  local -r EXTRACT_DIR="${ARCHIVE_DIR}/$(basename ${TOOLCHAIN_URL%.tar.xz})"
 
   local -r TOOLCHAIN_DIR=${ARCHIVE_DIR}/${TOOLCHAIN_RELATIVE_DIR}
   if [[ -d "${EXTRACT_DIR}" ]]; then
     mv "${EXTRACT_DIR}" "${TOOLCHAIN_DIR}"
   fi
 
-  local -r SYSROOT_DIR="${TOOLCHAIN_DIR}/${GCC_PREFIX}-buildroot-linux-gnu/sysroot"
+  local -r SYSROOT_DIR="${TOOLCHAIN_DIR}/${GCC_PREFIX}-buildroot-linux-gnu${GCC_SUFFIX}/sysroot"
   #local -r STAGING_DIR=${SYSROOT_DIR}-stage
 
   # Write a Toolchain file
@@ -362,13 +385,14 @@ DESCRIPTION
 \tYou MUST define the following variables before running this script:
 \t* TARGET:
 \t\tx86_64
-\t\taarch64 aarch64be (bootlin)
+\t\tarmv7-eabihf(arm) armebv7-eabihf(armeb) (bootlin)
+\t\taarch64(arm64) aarch64be(arm64be) (bootlin)
 \t\taarch64-linux-gnu aarch64_be-linux-gnu (linaro)
 \t\tarm-linux-gnueabihf armv8l-linux-gnueabihf arm-linux-gnueabi (linaro)
 \t\tarmeb-linux-gnueabihf armeb-linux-gnueabi (linaro)
 \t\tmips32 mips32el (codespace)
 \t\tmips64 mips64el (codespace)
-\t\tppc (bootlin)
+\t\tppc-440fp(ppc) ppc-e500mc (bootlin)
 \t\tppc64 ppc64le (bootlin)
 \t\triscv32 riscv64 (bootlin)
 \t\ts390x (bootlin)
@@ -430,10 +454,16 @@ function main() {
     aarch64_be-linux-gnu)
       expand_linaro_config
       declare -r QEMU_ARCH=aarch64_be ;;
-    aarch64)
+    arm | armv7-eabihf)
+      expand_bootlin_config
+      declare -r QEMU_ARCH=arm ;;
+    armeb | armebv7-eabihf)
+      expand_bootlin_config
+      declare -r QEMU_ARCH=DISABLED ;;
+    arm64 | aarch64)
       expand_bootlin_config
       declare -r QEMU_ARCH=aarch64 ;;
-    aarch64be)
+    arm64be | aarch64be)
       expand_bootlin_config
       declare -r QEMU_ARCH=aarch64_be ;;
     mips32)
@@ -448,21 +478,24 @@ function main() {
     mips64el)
       expand_codescape_config
       declare -r QEMU_ARCH=mips64el ;;
-    ppc64le)
-      expand_bootlin_config
-      declare -r QEMU_ARCH=ppc64le ;;
-    ppc64)
-      expand_bootlin_config
-      declare -r QEMU_ARCH=ppc64 ;;
-    ppc)
+
+    ppc | ppc-440fp | ppc-e500mc )
       expand_bootlin_config
       declare -r QEMU_ARCH=ppc ;;
+    ppc64 | ppc64-power8)
+      expand_bootlin_config
+      declare -r QEMU_ARCH=ppc64 ;;
+    ppc64le | ppc64le-power8)
+      expand_bootlin_config
+      declare -r QEMU_ARCH=ppc64le ;;
+
     riscv32)
       expand_bootlin_config
       declare -r QEMU_ARCH=riscv32 ;;
     riscv64)
       expand_bootlin_config
       declare -r QEMU_ARCH=riscv64 ;;
+
     s390x)
       expand_bootlin_config
       declare -r QEMU_ARCH=s390x ;;


### PR DESCRIPTION
Bump bootlin toolchains and fix all jobs
Also Bump qemu to 9.0.4
note: Lastest QEMU release (9.1.2) will break aarch[64]be jobs
see: https://gitlab.com/qemu-project/qemu/-/issues/2580