### PR TITLE
ci: Remove linaro toolchains support

### DIFF
--- a/.github/workflows/aarch64_linux_cmake.yml
+++ b/.github/workflows/aarch64_linux_cmake.yml
@@ -16,8 +16,6 @@ jobs:
         targets: [
           [aarch64],
           [aarch64be],
-          [aarch64-linux-gnu],
-          [aarch64_be-linux-gnu]
         ]
       fail-fast: false
     env:

--- a/.github/workflows/arm_linux_cmake.yml
+++ b/.github/workflows/arm_linux_cmake.yml
@@ -14,11 +14,8 @@ jobs:
     strategy:
       matrix:
         targets: [
-          [arm-linux-gnueabihf],
-          [armv8l-linux-gnueabihf],
-          [arm-linux-gnueabi],
-          [armeb-linux-gnueabihf],
-          [armeb-linux-gnueabi]
+          [armv7-eabihf],
+          [armebv7-eabihf],
         ]
       fail-fast: false
     env:

--- a/cmake/ci/Makefile
+++ b/cmake/ci/Makefile
@@ -39,13 +39,16 @@ help:
 	@echo -e "\t${BOLD}clean_<target>_<toolchain_stage>${RESET}: Remove cache and docker image."
 	@echo
 	@echo -e "\tWith ${BOLD}<target>${RESET}:"
-	@echo -e "\t\t${BOLD}aarch64${RESET} (bootlin toolchain)"
-	@echo -e "\t\t${BOLD}aarch64be${RESET} (bootlin toolchain)"
+	@echo -e "\t\t${BOLD}armv7-eabihf(arm)${RESET} (bootlin toolchain)"
+	@echo -e "\t\t${BOLD}armebv7-eabihf(armeb)${RESET} (bootlin toolchain)"
+	@echo -e "\t\t${BOLD}aarch64(arm64)${RESET} (bootlin toolchain)"
+	@echo -e "\t\t${BOLD}aarch64be(arm64be)${RESET} (bootlin toolchain)"
 	@echo -e "\t\t${BOLD}mips32${RESET} (codespace toolchain)"
 	@echo -e "\t\t${BOLD}mips64${RESET} (codespace toolchain)"
 	@echo -e "\t\t${BOLD}mips32el${RESET} (codespace toolchain)"
 	@echo -e "\t\t${BOLD}mips64el${RESET} (codespace toolchain)"
-	@echo -e "\t\t${BOLD}ppc${RESET} (bootlin toolchain)"
+	@echo -e "\t\t${BOLD}ppc-440fp(ppc)${RESET} (bootlin toolchain)"
+	@echo -e "\t\t${BOLD}ppc-e500mc${RESET} (bootlin toolchain)"
 	@echo -e "\t\t${BOLD}ppc64${RESET} (bootlin toolchain)"
 	@echo -e "\t\t${BOLD}ppc64le${RESET} (bootlin toolchain)"
 	@echo -e "\t\t${BOLD}riscv32${RESET} (bootlin toolchain)"
@@ -144,6 +147,9 @@ $(clean_targets_amd64): clean_amd64_%:
 ## TOOLCHAIN ##
 ###############
 TOOLCHAIN_TARGETS = \
+ arm armeb \
+ armv7-eabihf armebv7-eabihf \
+ arm64 arm64be \
  aarch64 aarch64be \
  mips32 mips32el mips64 mips64el \
  ppc ppc-440fp ppc-e500mc \

--- a/cmake/ci/Makefile
+++ b/cmake/ci/Makefile
@@ -39,14 +39,7 @@ help:
 	@echo -e "\t${BOLD}clean_<target>_<toolchain_stage>${RESET}: Remove cache and docker image."
 	@echo
 	@echo -e "\tWith ${BOLD}<target>${RESET}:"
-	@echo -e "\t\t${BOLD}arm-linux-gnueabihf${RESET} (linaro toolchain)"
-	@echo -e "\t\t${BOLD}armv8l-linux-gnueabihf${RESET} (linaro toolchain)"
-	@echo -e "\t\t${BOLD}arm-linux-gnueabi${RESET} (linaro toolchain)"
-	@echo -e "\t\t${BOLD}armeb-linux-gnueabihf${RESET} (linaro toolchain)"
-	@echo -e "\t\t${BOLD}armeb-linux-gnueabi${RESET} (linaro toolchain)"
-	@echo -e "\t\t${BOLD}aarch64-linux-gnu${RESET} (linaro toolchain)"
 	@echo -e "\t\t${BOLD}aarch64${RESET} (bootlin toolchain)"
-	@echo -e "\t\t${BOLD}aarch64_be-linux-gnu${RESET} (linaro toolchain)"
 	@echo -e "\t\t${BOLD}aarch64be${RESET} (bootlin toolchain)"
 	@echo -e "\t\t${BOLD}mips32${RESET} (codespace toolchain)"
 	@echo -e "\t\t${BOLD}mips64${RESET} (codespace toolchain)"
@@ -152,8 +145,6 @@ $(clean_targets_amd64): clean_amd64_%:
 ###############
 TOOLCHAIN_TARGETS = \
  aarch64 aarch64be \
- arm-linux-gnueabihf armv8l-linux-gnueabihf arm-linux-gnueabi armeb-linux-gnueabihf armeb-linux-gnueabi \
- aarch64-linux-gnu aarch64_be-linux-gnu \
  mips32 mips32el mips64 mips64el \
  ppc ppc-440fp ppc-e500mc \
  ppc64 ppc64le \

--- a/scripts/run_integration.sh
+++ b/scripts/run_integration.sh
@@ -92,50 +92,6 @@ function clean_build() {
   mkdir -p "${BUILD_DIR}"
 }
 
-function expand_linaro_config() {
-  #ref: https://releases.linaro.org/components/toolchain/binaries/
-  local -r LINARO_VERSION=7.5-2019.12
-  local -r LINARO_ROOT_URL=https://releases.linaro.org/components/toolchain/binaries/${LINARO_VERSION}
-
-  local -r GCC_VERSION=7.5.0-2019.12
-  local -r GCC_URL=${LINARO_ROOT_URL}/${TARGET}/gcc-linaro-${GCC_VERSION}-x86_64_${TARGET}.tar.xz
-  local -r GCC_RELATIVE_DIR="gcc-linaro-${GCC_VERSION}-x86_64_${TARGET}"
-  unpack "${GCC_URL}" "${GCC_RELATIVE_DIR}"
-
-  local -r SYSROOT_VERSION=2.25-2019.12
-  local -r SYSROOT_URL=${LINARO_ROOT_URL}/${TARGET}/sysroot-glibc-linaro-${SYSROOT_VERSION}-${TARGET}.tar.xz
-  local -r SYSROOT_RELATIVE_DIR=sysroot-glibc-linaro-${SYSROOT_VERSION}-${TARGET}
-  unpack "${SYSROOT_URL}" "${SYSROOT_RELATIVE_DIR}"
-
-  local -r SYSROOT_DIR=${ARCHIVE_DIR}/${SYSROOT_RELATIVE_DIR}
-  local -r STAGING_DIR=${ARCHIVE_DIR}/${SYSROOT_RELATIVE_DIR}-stage
-  local -r GCC_DIR=${ARCHIVE_DIR}/${GCC_RELATIVE_DIR}
-
-  # Write a Toolchain file
-  # note: This is manadatory to use a file in order to have the CMake variable
-  # 'CMAKE_CROSSCOMPILING' set to TRUE.
-  # ref: https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-linux
-  cat >"$TOOLCHAIN_FILE" <<EOL
-set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_PROCESSOR ${TARGET})
-
-set(CMAKE_SYSROOT ${SYSROOT_DIR})
-set(CMAKE_STAGING_PREFIX ${STAGING_DIR})
-
-set(tools ${GCC_DIR})
-set(CMAKE_C_COMPILER \${tools}/bin/${TARGET}-gcc)
-set(CMAKE_CXX_COMPILER \${tools}/bin/${TARGET}-g++)
-
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
-EOL
-CMAKE_ADDITIONAL_ARGS+=( -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN_FILE}" )
-QEMU_ARGS+=( -L "${SYSROOT_DIR}" )
-QEMU_ARGS+=( -E LD_LIBRARY_PATH=/lib )
-}
-
 function expand_bootlin_config() {
   # ref: https://toolchains.bootlin.com/
   local -r GCC_DIR=${ARCHIVE_DIR}/${GCC_RELATIVE_DIR}
@@ -388,9 +344,6 @@ DESCRIPTION
 \t\tx86_64
 \t\tarmv7-eabihf(arm) armebv7-eabihf(armeb) (bootlin)
 \t\taarch64(arm64) aarch64be(arm64be) (bootlin)
-\t\taarch64-linux-gnu aarch64_be-linux-gnu (linaro)
-\t\tarm-linux-gnueabihf armv8l-linux-gnueabihf arm-linux-gnueabi (linaro)
-\t\tarmeb-linux-gnueabihf armeb-linux-gnueabi (linaro)
 \t\tmips32 mips32el (codespace)
 \t\tmips64 mips64el (codespace)
 \t\tppc-440fp(ppc) ppc-e500mc (bootlin)
@@ -443,18 +396,6 @@ function main() {
   case ${TARGET} in
     x86_64)
       declare -r QEMU_ARCH=x86_64 ;;
-    arm-linux-gnueabihf | armv8l-linux-gnueabihf | arm-linux-gnueabi)
-      expand_linaro_config
-      declare -r QEMU_ARCH=arm ;;
-    armeb-linux-gnueabihf | armeb-linux-gnueabi)
-      expand_linaro_config
-      declare -r QEMU_ARCH=DISABLED ;;
-    aarch64-linux-gnu)
-      expand_linaro_config
-      declare -r QEMU_ARCH=aarch64 ;;
-    aarch64_be-linux-gnu)
-      expand_linaro_config
-      declare -r QEMU_ARCH=aarch64_be ;;
     arm | armv7-eabihf)
       expand_bootlin_config
       declare -r QEMU_ARCH=arm ;;
@@ -467,6 +408,7 @@ function main() {
     arm64be | aarch64be)
       expand_bootlin_config
       declare -r QEMU_ARCH=aarch64_be ;;
+
     mips32)
       expand_codescape_config
       declare -r QEMU_ARCH=mips ;;


### PR DESCRIPTION
All toolchains have not been updated since 2019...
Also linaro website do not advertise them...
ref: https://www.linaro.org/downloads

note: new link point to https://snapshots.linaro.org/gnu-toolchain/ which only provide two flavors (aarch64 and arm-gnueabihf (ed also provided by bootlin)) with a warning disclaimer:
> These builds are for experimental environments only. They will break your stuff and drink all your beer. You have been warned.

ref: https://snapshots.linaro.org/gnu-toolchain/14.0-2023.06-1/