### PR TITLE
Run GitHub Workflow aarch64_linux_bazel on an ARM processor

### DIFF
--- a/.github/workflows/aarch64_linux_bazel.yml
+++ b/.github/workflows/aarch64_linux_bazel.yml
@@ -8,18 +8,12 @@ on:
     - cron: '0 0 7,22 * *'
 
 jobs:
-  # Building using the github runner environement directly.
+  # Building using the GitHub runner environement directly.
   bazel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Check docker
-        run: |
-          docker info
-          docker buildx ls
       - name: Build
         run: make --directory=bazel/ci arm64_build
       - name: Test


### PR DESCRIPTION
[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `ubuntu-24.04-arm`

Accelerate the longest running GitHub Action job.

Currently, the `aarch64_linux_bazel` job takes three times longer to run than the other GitHub Actions jobs.