### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ option(BUILD_SHARED_LIBS "Build library as shared." OFF)
 # Force PIC on unix when building shared libs
 # see: https://en.wikipedia.org/wiki/Position-independent_code
 if(BUILD_SHARED_LIBS AND UNIX)
-  option(CMAKE_POSITION_INDEPENDENT_CODE "Build with Position Independant Code." ON)
+  option(CMAKE_POSITION_INDEPENDENT_CODE "Build with Position Independent Code." ON)
 endif()
 
 include(CheckIncludeFile)

--- a/cmake/ci/README.md
+++ b/cmake/ci/README.md
@@ -28,7 +28,7 @@ make mips32_test
 ```
 
 ### Docker layers
-Dockerfile is splitted in several stages.
+Dockerfile is split in several stages.
 
 ![docker](doc/docker.svg)
 

--- a/include/cpuinfo_ppc.h
+++ b/include/cpuinfo_ppc.h
@@ -99,7 +99,7 @@ typedef enum {
   PPC_HAS_MMU,     /* Memory management unit */
   PPC_HAS_4xxMAC,
   PPC_UNIFIED_CACHE,  /* Unified instruction and data cache */
-  PPC_HAS_SPE,        /* Signal processing extention unit */
+  PPC_HAS_SPE,        /* Signal processing extension unit */
   PPC_HAS_EFP_SINGLE, /* SPE single precision fpu */
   PPC_HAS_EFP_DOUBLE, /* SPE double precision fpu */
   PPC_NO_TB,          /* No timebase */
@@ -116,7 +116,7 @@ typedef enum {
   PPC_POWER6_EXT,
   PPC_ARCH_2_06,              /* ISA 2.06 - POWER7 */
   PPC_HAS_VSX,                /* Vector-scalar extension */
-  PPC_PSERIES_PERFMON_COMPAT, /* Set of backwards compatibile performance
+  PPC_PSERIES_PERFMON_COMPAT, /* Set of backwards compatible performance
                                  monitoring events */
   PPC_TRUE_LE,
   PPC_PPC_LE,

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -126,7 +126,7 @@ typedef struct {
 // Calls cpuid and returns an initialized X86info.
 X86Info GetX86Info(void);
 
-// Returns cache hierarchy informations.
+// Returns cache hierarchy information.
 // Can call cpuid multiple times.
 CacheInfo GetX86CacheInfo(void);
 

--- a/ndk_compat/cpu-features.h
+++ b/ndk_compat/cpu-features.h
@@ -186,7 +186,7 @@ extern uint64_t android_getCpuFeatures(void);
  *     This flag implies -mfpu=neon-vfpv4.
  *
  *   -mcpu=iwmmxt
- *     Allows the use of iWMMXt instrinsics with GCC.
+ *     Allows the use of iWMMXt intrinsics with GCC.
  *
  * IMPORTANT NOTE: These flags should only be tested when
  * android_getCpuFamily() returns ANDROID_CPU_FAMILY_ARM, i.e. this is a

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -8,7 +8,7 @@ FINISHED='\033[1;96m'
 NOCOLOR='\033[0m'
 ERROR='\033[0;31m'
 
-echo -e "${ACTION}Checking environnement${NOCOLOR}"
+echo -e "${ACTION}Checking environment${NOCOLOR}"
 if [[ ! $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 then
     echo -e "${ERROR}Invalid version number. Aborting. ${NOCOLOR}"
@@ -40,7 +40,7 @@ fi
 git update-index -q --refresh
 if ! git diff-index --quiet HEAD --
 then
-    echo -e "${ERROR}Branch has uncommited changes. Aborting.${NOCOLOR}"
+    echo -e "${ERROR}Branch has uncommitted changes. Aborting.${NOCOLOR}"
     exit 1
 fi
 

--- a/src/impl_ppc_linux.c
+++ b/src/impl_ppc_linux.c
@@ -127,7 +127,7 @@ static const PPCInfo kEmptyPPCInfo;
 PPCInfo GetPPCInfo(void) {
   /*
    * On Power feature flags aren't currently in cpuinfo so we only look at
-   * the auxilary vector.
+   * the auxiliary vector.
    */
   PPCInfo info = kEmptyPPCInfo;
   const HardwareCapabilities hwcaps = CpuFeatures_GetHardwareCapabilities();

--- a/test/cpuinfo_mips_test.cc
+++ b/test/cpuinfo_mips_test.cc
@@ -122,7 +122,7 @@ TEST(CpuinfoMipsTest, Goldfish) {
   auto& fs = GetEmptyFilesystem();
   fs.CreateFile("/proc/cpuinfo", R"(system type		: MIPS-Goldfish
 Hardware		: goldfish
-Revison		: 1
+Revision		: 1
 processor		: 0
 cpu model		: MIPS 24Kc V0.0  FPU V0.0
 BogoMIPS		: 1042.02


### PR DESCRIPTION
% `codespell --ignore-words-list=hart,sie,sme,te,tha --write-changes`
* https://github.com/codespell-project/codespell