### PR TITLE
Fixed asimd detection on OS X 15.3

### DIFF
--- a/src/impl_aarch64_macos_or_iphone.c
+++ b/src/impl_aarch64_macos_or_iphone.c
@@ -52,7 +52,7 @@ Aarch64Info GetAarch64Info(void) {
   info.revision = GetDarwinSysCtlByNameValue("hw.cpusubfamily");
 
   info.features.fp = GetDarwinSysCtlByName("hw.optional.floatingpoint");
-  info.features.asimd = GetDarwinSysCtlByName("hw.optional.AdvSIMD");
+  info.features.asimd = GetDarwinSysCtlByName("hw.optional.AdvSIMD") || GetDarwinSysCtlByName("hw.optional.arm.AdvSIMD");
   info.features.aes = GetDarwinSysCtlByName("hw.optional.arm.FEAT_AES");
   info.features.pmull = GetDarwinSysCtlByName("hw.optional.arm.FEAT_PMULL");
   info.features.sha1 = GetDarwinSysCtlByName("hw.optional.arm.FEAT_SHA1");


### PR DESCRIPTION
Fixes #390 