### PR TITLE
Update AArch64 features to Linux 6.12.

### DIFF
--- a/include/cpuinfo_aarch64.h
+++ b/include/cpuinfo_aarch64.h
@@ -217,6 +217,7 @@ typedef struct {
                       // (4-way) instructions.
   int smesf8dp2 : 1;  // SVE2 FP8 to half-precision 2-way dot product FDOT
                       // (2-way) instructions.
+  int poe : 1;        // Stage 1 Permission Overlay.
 
   // Make sure to update Aarch64FeaturesEnum below if you add a field here.
 } Aarch64Features;
@@ -331,6 +332,7 @@ typedef enum {
   AARCH64_SME_SF8FMA,
   AARCH64_SME_SF8DP4,
   AARCH64_SME_SF8DP2,
+  AARCH64_POE,
   AARCH64_LAST_,
 } Aarch64FeaturesEnum;
 

--- a/include/internal/hwcaps.h
+++ b/include/internal/hwcaps.h
@@ -124,6 +124,7 @@ CPU_FEATURES_START_CPP_NAMESPACE
 #define AARCH64_HWCAP2_SME_SF8FMA (1UL << 60)
 #define AARCH64_HWCAP2_SME_SF8DP4 (1UL << 61)
 #define AARCH64_HWCAP2_SME_SF8DP2 (1UL << 62)
+#define AARCH64_HWCAP2_POE (1UL << 63)
 
 // http://elixir.free-electrons.com/linux/latest/source/arch/arm/include/uapi/asm/hwcap.h
 #define ARM_HWCAP_SWP (1UL << 0)

--- a/src/impl_aarch64__base_implementation.inl
+++ b/src/impl_aarch64__base_implementation.inl
@@ -136,7 +136,9 @@
        AARCH64_HWCAP2_SME_SF8FMA)                                            \
   LINE(AARCH64_SME_SF8DP4, smesf8dp4, "smesf8dp4", 0,                        \
        AARCH64_HWCAP2_SME_SF8DP4)                                            \
-  LINE(AARCH64_SME_SF8DP2, smesf8dp2, "smesf8dp2", 0, AARCH64_HWCAP2_SME_SF8DP2)
+  LINE(AARCH64_SME_SF8DP2, smesf8dp2, "smesf8dp2", 0,                        \
+       AARCH64_HWCAP2_SME_SF8DP2)                                            \
+  LINE(AARCH64_POE, poe, "poe", 0, AARCH64_HWCAP2_POE)
 
 #define INTROSPECTION_PREFIX Aarch64
 #define INTROSPECTION_ENUM_PREFIX AARCH64

--- a/test/cpuinfo_aarch64_test.cc
+++ b/test/cpuinfo_aarch64_test.cc
@@ -330,6 +330,7 @@ CPU revision    : 3)");
   EXPECT_FALSE(info.features.smesf8fma);
   EXPECT_FALSE(info.features.smesf8dp4);
   EXPECT_FALSE(info.features.smesf8dp2);
+  EXPECT_FALSE(info.features.poe);
 }
 #elif defined(CPU_FEATURES_OS_MACOS)
 TEST_F(CpuidAarch64Test, FromDarwinSysctlFromName) {


### PR DESCRIPTION
Hi,
this is an update to the Linux kernel version 6.12.

Best,
Peter T.