### PR TITLE
cmake: Fix googletest build

### DIFF
--- a/cmake/googletest.CMakeLists.txt.in
+++ b/cmake/googletest.CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.16)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
note: googletest require cmake 3.16 as its minimum, this should fix macos ci jobs and few others...

ref: https://github.com/google/googletest/blob/2ce9d8f2e85550a94d6ac977c881fe3658129ac6/CMakeLists.txt#L4
