### PR TITLE
ci: use macos-15-intel runners

### DIFF
--- a/.github/workflows/amd64_macos_bazel.yml
+++ b/.github/workflows/amd64_macos_bazel.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   # Building using the github runner environement directly.
   bazel:
-    runs-on: macos-13 # Using x86 processors, ref: https://github.com/actions/runner-images
+    runs-on: macos-15-intel  # Using x86 processors
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5

--- a/.github/workflows/amd64_macos_cmake.yml
+++ b/.github/workflows/amd64_macos_cmake.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   # Building using the github runner environement directly.
   xcode:
-    runs-on: macos-13 # Using x86 processors, ref: https://github.com/actions/runner-images
+    runs-on: macos-15-intel  # Using x86 processors
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
     steps:


### PR DESCRIPTION
ref: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/