### PR TITLE
Added support TCC compiler in cpuid

### DIFF
--- a/include/cpu_features_macros.h
+++ b/include/cpu_features_macros.h
@@ -130,13 +130,11 @@
 
 #if defined(__clang__)
 #define CPU_FEATURES_COMPILER_CLANG
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
+#elif defined(__TINYC__)
+#define CPU_FEATURES_COMPILER_TCC
+#elif defined(__GNUC__)
 #define CPU_FEATURES_COMPILER_GCC
-#endif
-
-#if defined(_MSC_VER)
+#elif defined(_MSC_VER)
 #define CPU_FEATURES_COMPILER_MSC
 #endif
 

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -121,6 +121,23 @@ uint32_t GetXCR0Eax(void) {
   return eax;
 }
 
+#elif defined(CPU_FEATURES_COMPILER_TCC)
+
+Leaf GetCpuidLeaf(uint32_t leaf_id, int ecx) {
+  Leaf leaf;
+  __asm__ __volatile__(
+      "cpuid"
+      : "=a"(leaf.eax), "=b"(leaf.ebx), "=c"(leaf.ecx), "=d"(leaf.edx)
+      : "a"(leaf_id), "c"(ecx));
+  return leaf;
+}
+
+uint32_t GetXCR0Eax(void) {
+  uint32_t eax, edx;
+  __asm__ __volatile__(".byte 0x0F, 0x01, 0xd0" : "=a"(eax), "=d"(edx) : "c"(0));
+  return eax;
+}
+
 #elif defined(CPU_FEATURES_COMPILER_MSC)
 
 #include <immintrin.h>


### PR DESCRIPTION
This is a really cool Bellard project, I'm surprised how TCC compiles ~8-10 times faster than GCC and Clang.

My benchmarks for TCC compiler:
- https://github.com/htop-dev/htop/pull/1978
- https://github.com/Atoptool/atop/pull/375

Wiki: https://en.wikipedia.org/wiki/Tiny_C_Compiler
Official site: https://bellard.org/tcc/