### PR TITLE
Add support for AMD Zen 5, Intel Arrow Lake and Intel Lunar Lake microarchitectures

### DIFF
--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -188,7 +188,7 @@ typedef enum {
   AMD_ZEN2,             // K17 ZEN 2
   AMD_ZEN3,             // K19 ZEN 3
   AMD_ZEN4,             // K19 ZEN 4
-  AMD_ZEN5,             // K1A ZEN 4
+  AMD_ZEN5,             // K1A ZEN 5
   X86_MICROARCHITECTURE_LAST_,
 } X86Microarchitecture;
 

--- a/include/cpuinfo_x86.h
+++ b/include/cpuinfo_x86.h
@@ -165,6 +165,8 @@ typedef enum {
   INTEL_ADL,            // ALDER LAKE
   INTEL_RCL,            // ROCKET LAKE
   INTEL_RPL,            // RAPTOR LAKE
+  INTEL_LNL,            // LUNAR LAKE
+  INTEL_ARL,            // ARROW LAKE
   INTEL_KNIGHTS_M,      // KNIGHTS MILL
   INTEL_KNIGHTS_L,      // KNIGHTS LANDING
   INTEL_KNIGHTS_F,      // KNIGHTS FERRY
@@ -186,6 +188,7 @@ typedef enum {
   AMD_ZEN2,             // K17 ZEN 2
   AMD_ZEN3,             // K19 ZEN 3
   AMD_ZEN4,             // K19 ZEN 4
+  AMD_ZEN5,             // K1A ZEN 4
   X86_MICROARCHITECTURE_LAST_,
 } X86Microarchitecture;
 

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -658,7 +658,6 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x06, 0xA7):
         // https://en.wikichip.org/wiki/intel/microarchitectures/rocket_lake
         return INTEL_RCL;
-
       case CPUID(0x06, 0xB7):
       case CPUID(0x06, 0xBA):
       case CPUID(0x06, 0xBF):

--- a/src/impl_x86__base_implementation.inl
+++ b/src/impl_x86__base_implementation.inl
@@ -511,7 +511,7 @@ X86Info GetX86Info(void) {
 // Microarchitecture
 ////////////////////////////////////////////////////////////////////////////////
 
-#define CPUID(FAMILY, MODEL) ((((FAMILY)&0xFF) << 8) | ((MODEL)&0xFF))
+#define CPUID(FAMILY, MODEL) ((((FAMILY) & 0xFF) << 8) | ((MODEL) & 0xFF))
 
 X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
   if (IsVendorByX86Info(info, CPU_FEATURES_VENDOR_GENUINE_INTEL)) {
@@ -658,11 +658,20 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x06, 0xA7):
         // https://en.wikichip.org/wiki/intel/microarchitectures/rocket_lake
         return INTEL_RCL;
+
       case CPUID(0x06, 0xB7):
       case CPUID(0x06, 0xBA):
       case CPUID(0x06, 0xBF):
         // https://en.wikichip.org/wiki/intel/microarchitectures/raptor_lake
         return INTEL_RPL;
+      case CPUID(0x06, 0xBD):
+        // https://github.com/torvalds/linux/blob/70eda68668d1476b459b64e69b8f36659fa9dfa8/arch/x86/include/asm/intel-family.h#L151
+        return INTEL_LNL;
+      case CPUID(0x06, 0xC5):
+      case CPUID(0x06, 0xC6):
+      case CPUID(0x06, 0xB5):
+        // https://github.com/torvalds/linux/blob/70eda68668d1476b459b64e69b8f36659fa9dfa8/arch/x86/include/asm/intel-family.h#L147
+        return INTEL_ARL;
       case CPUID(0x06, 0x85):
         // https://en.wikichip.org/wiki/intel/microarchitectures/knights_mill
         return INTEL_KNIGHTS_M;
@@ -841,6 +850,129 @@ X86Microarchitecture GetX86Microarchitecture(const X86Info* info) {
       case CPUID(0x19, 0x74):
         // https://en.wikichip.org/wiki/amd/microarchitectures/zen_4
         return AMD_ZEN4;
+      // Breithorn
+      case CPUID(0x1A, 0x00):
+      case CPUID(0x1A, 0x01):
+      case CPUID(0x1A, 0x02):
+      case CPUID(0x1A, 0x03):
+      case CPUID(0x1A, 0x04):
+      case CPUID(0x1A, 0x05):
+      case CPUID(0x1A, 0x06):
+      case CPUID(0x1A, 0x07):
+      case CPUID(0x1A, 0x08):
+      case CPUID(0x1A, 0x09):
+      case CPUID(0x1A, 0x0A):
+      case CPUID(0x1A, 0x0B):
+      case CPUID(0x1A, 0x0C):
+      case CPUID(0x1A, 0x0D):
+      case CPUID(0x1A, 0x0E):
+      case CPUID(0x1A, 0x0F):
+      // Breithorn-dense
+      case CPUID(0x1A, 0x10):
+      case CPUID(0x1A, 0x11):
+      case CPUID(0x1A, 0x12):
+      case CPUID(0x1A, 0x13):
+      case CPUID(0x1A, 0x14):
+      case CPUID(0x1A, 0x15):
+      case CPUID(0x1A, 0x16):
+      case CPUID(0x1A, 0x17):
+      case CPUID(0x1A, 0x18):
+      case CPUID(0x1A, 0x19):
+      case CPUID(0x1A, 0x1A):
+      case CPUID(0x1A, 0x1B):
+      case CPUID(0x1A, 0x1C):
+      case CPUID(0x1A, 0x1D):
+      case CPUID(0x1A, 0x1E):
+      case CPUID(0x1A, 0x1F):
+      // Strix 1
+      case CPUID(0x1A, 0x20):
+      case CPUID(0x1A, 0x21):
+      case CPUID(0x1A, 0x22):
+      case CPUID(0x1A, 0x23):
+      case CPUID(0x1A, 0x24):
+      case CPUID(0x1A, 0x25):
+      case CPUID(0x1A, 0x26):
+      case CPUID(0x1A, 0x27):
+      case CPUID(0x1A, 0x28):
+      case CPUID(0x1A, 0x29):
+      case CPUID(0x1A, 0x2A):
+      case CPUID(0x1A, 0x2B):
+      case CPUID(0x1A, 0x2C):
+      case CPUID(0x1A, 0x2D):
+      case CPUID(0x1A, 0x2E):
+      case CPUID(0x1A, 0x2F):
+      // Strix 2
+      case CPUID(0x1A, 0x30):
+      case CPUID(0x1A, 0x31):
+      case CPUID(0x1A, 0x32):
+      case CPUID(0x1A, 0x33):
+      case CPUID(0x1A, 0x34):
+      case CPUID(0x1A, 0x35):
+      case CPUID(0x1A, 0x36):
+      case CPUID(0x1A, 0x37):
+      // Strix 3
+      case CPUID(0x1A, 0x38):
+      case CPUID(0x1A, 0x39):
+      case CPUID(0x1A, 0x3A):
+      case CPUID(0x1A, 0x3B):
+      case CPUID(0x1A, 0x3C):
+      case CPUID(0x1A, 0x3D):
+      case CPUID(0x1A, 0x3E):
+      case CPUID(0x1A, 0x3F):
+      // Granite ridge
+      case CPUID(0x1A, 0x40):
+      case CPUID(0x1A, 0x41):
+      case CPUID(0x1A, 0x42):
+      case CPUID(0x1A, 0x43):
+      case CPUID(0x1A, 0x44):
+      case CPUID(0x1A, 0x45):
+      case CPUID(0x1A, 0x46):
+      case CPUID(0x1A, 0x47):
+      case CPUID(0x1A, 0x48):
+      case CPUID(0x1A, 0x49):
+      case CPUID(0x1A, 0x4A):
+      case CPUID(0x1A, 0x4B):
+      case CPUID(0x1A, 0x4C):
+      case CPUID(0x1A, 0x4D):
+      case CPUID(0x1A, 0x4E):
+      case CPUID(0x1A, 0x4F):
+      // Krackan1
+      case CPUID(0x1A, 0x60):
+      case CPUID(0x1A, 0x61):
+      case CPUID(0x1A, 0x62):
+      case CPUID(0x1A, 0x63):
+      case CPUID(0x1A, 0x64):
+      case CPUID(0x1A, 0x65):
+      case CPUID(0x1A, 0x66):
+      case CPUID(0x1A, 0x67):
+      case CPUID(0x1A, 0x68):
+      case CPUID(0x1A, 0x69):
+      case CPUID(0x1A, 0x6A):
+      case CPUID(0x1A, 0x6B):
+      case CPUID(0x1A, 0x6C):
+      case CPUID(0x1A, 0x6D):
+      case CPUID(0x1A, 0x6E):
+      case CPUID(0x1A, 0x6F):
+      // Sarlak
+      case CPUID(0x1A, 0x70):
+      case CPUID(0x1A, 0x71):
+      case CPUID(0x1A, 0x72):
+      case CPUID(0x1A, 0x73):
+      case CPUID(0x1A, 0x74):
+      case CPUID(0x1A, 0x75):
+      case CPUID(0x1A, 0x76):
+      case CPUID(0x1A, 0x77):
+      // Annapurna
+      case CPUID(0x1A, 0xD0):
+      case CPUID(0x1A, 0xD1):
+      case CPUID(0x1A, 0xD2):
+      case CPUID(0x1A, 0xD3):
+      case CPUID(0x1A, 0xD4):
+      case CPUID(0x1A, 0xD5):
+      case CPUID(0x1A, 0xD6):
+      case CPUID(0x1A, 0xD7):
+        // https://github.com/llvm/llvm-project/blob/c998fcb0d1757309656ee0dfe4f2aa8dcf06aecc/llvm/lib/TargetParser/Host.cpp#L1328
+        return AMD_ZEN5;
       default:
         return X86_UNKNOWN;
     }
@@ -2038,6 +2170,8 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(INTEL_ADL)                   \
   LINE(INTEL_RCL)                   \
   LINE(INTEL_RPL)                   \
+  LINE(INTEL_LNL)                   \
+  LINE(INTEL_ARL)                   \
   LINE(INTEL_KNIGHTS_M)             \
   LINE(INTEL_KNIGHTS_L)             \
   LINE(INTEL_KNIGHTS_F)             \
@@ -2058,7 +2192,8 @@ CacheInfo GetX86CacheInfo(void) {
   LINE(AMD_ZEN_PLUS)                \
   LINE(AMD_ZEN2)                    \
   LINE(AMD_ZEN3)                    \
-  LINE(AMD_ZEN4)
+  LINE(AMD_ZEN4)                    \
+  LINE(AMD_ZEN5)
 
 const char* GetX86MicroarchitectureName(X86Microarchitecture value) {
 #define LINE(ENUM) [ENUM] = STRINGIZE(ENUM),


### PR DESCRIPTION
I've added support for AMD Zen 5, Intel Arrow Lake and Intel Lunar Lake microarchitectures.

**Sources**
because wikichip is down (probably indefinitely?), I've sourced the chip family and model values from the Linux kernel and LLVM github. I've included permalinks to the exact sources in the code.

The code compiles locally and all the ctests pass. I am unaware of how much the CMake ctests actually test, but all of them pass. I am not sure if further testing is needed.

This closes #449.