### PR TITLE
Added checks result.full_line in detect features and handle arm64 line

### DIFF
--- a/src/impl_aarch64_linux_or_android.c
+++ b/src/impl_aarch64_linux_or_android.c
@@ -21,6 +21,7 @@
 
 static bool HandleAarch64Line(const LineResult result,
                               Aarch64Info* const info) {
+  if (!result.full_line) return !result.eof;
   StringView line = result.line;
   StringView key, value;
   if (CpuFeatures_StringView_GetAttributeKeyValue(line, &key, &value)) {

--- a/src/impl_x86_linux_or_android.c
+++ b/src/impl_x86_linux_or_android.c
@@ -37,6 +37,7 @@ static void DetectFeaturesFromOs(X86Info* info, X86Features* features) {
     for (bool stop = false; !stop;) {
       const LineResult result = StackLineReader_NextLine(&reader);
       if (result.eof) stop = true;
+      if (!result.full_line) continue;
       const StringView line = result.line;
       StringView key, value;
       if (!CpuFeatures_StringView_GetAttributeKeyValue(line, &key, &value))


### PR DESCRIPTION
result.full_line is not checked. If flags line in /proc/cpuinfo is longer than STACK_LINE_READER_BUFFER_SIZE, it will be truncated, and some CPU features might not be detected. 

In the future, CPU features string will grow in length as processor SIMD instructions appear frequently.