### PR TITLE
ci: add least-privilege read-only token permissions (22 workflows)

### DIFF
--- a/.github/workflows/aarch64_linux_bazel.yml
+++ b/.github/workflows/aarch64_linux_bazel.yml
@@ -7,6 +7,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the GitHub runner environement directly.
   bazel:

--- a/.github/workflows/aarch64_linux_cmake.yml
+++ b/.github/workflows/aarch64_linux_cmake.yml
@@ -7,6 +7,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   make:

--- a/.github/workflows/aarch64_linux_zig.yml
+++ b/.github/workflows/aarch64_linux_zig.yml
@@ -2,6 +2,9 @@ name: aarch64 Linux Zig
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     strategy:

--- a/.github/workflows/amd64_linux_bazel.yml
+++ b/.github/workflows/amd64_linux_bazel.yml
@@ -7,6 +7,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   bazel:

--- a/.github/workflows/amd64_linux_cmake.yml
+++ b/.github/workflows/amd64_linux_cmake.yml
@@ -7,6 +7,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   make:

--- a/.github/workflows/amd64_linux_zig.yml
+++ b/.github/workflows/amd64_linux_zig.yml
@@ -2,6 +2,9 @@ name: amd64 Linux Zig
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     strategy:

--- a/.github/workflows/amd64_macos_bazel.yml
+++ b/.github/workflows/amd64_macos_bazel.yml
@@ -8,6 +8,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   bazel:

--- a/.github/workflows/amd64_macos_cmake.yml
+++ b/.github/workflows/amd64_macos_cmake.yml
@@ -8,6 +8,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   xcode:

--- a/.github/workflows/amd64_macos_zig.yml
+++ b/.github/workflows/amd64_macos_zig.yml
@@ -2,6 +2,9 @@ name: amd64 MacOS Zig
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     strategy:

--- a/.github/workflows/amd64_windows_bazel.yml
+++ b/.github/workflows/amd64_windows_bazel.yml
@@ -8,6 +8,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   bazel:

--- a/.github/workflows/amd64_windows_cmake.yml
+++ b/.github/workflows/amd64_windows_cmake.yml
@@ -7,6 +7,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   msvc:

--- a/.github/workflows/amd64_windows_zig.yml
+++ b/.github/workflows/amd64_windows_zig.yml
@@ -2,6 +2,9 @@ name: amd64 Windows Zig
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     strategy:

--- a/.github/workflows/arm64_macos_bazel.yml
+++ b/.github/workflows/arm64_macos_bazel.yml
@@ -8,6 +8,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   bazel:

--- a/.github/workflows/arm64_macos_cmake.yml
+++ b/.github/workflows/arm64_macos_cmake.yml
@@ -8,6 +8,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   xcode:

--- a/.github/workflows/arm64_macos_zig.yml
+++ b/.github/workflows/arm64_macos_zig.yml
@@ -2,6 +2,9 @@ name: Arm64 MacOS Zig
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     strategy:

--- a/.github/workflows/arm_linux_cmake.yml
+++ b/.github/workflows/arm_linux_cmake.yml
@@ -7,6 +7,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   make:

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -2,6 +2,9 @@ name: clang-format Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   clang-format:

--- a/.github/workflows/mips_linux_cmake.yml
+++ b/.github/workflows/mips_linux_cmake.yml
@@ -7,6 +7,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   make:

--- a/.github/workflows/power_linux_cmake.yml
+++ b/.github/workflows/power_linux_cmake.yml
@@ -7,6 +7,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   make:

--- a/.github/workflows/riscv_linux_cmake.yml
+++ b/.github/workflows/riscv_linux_cmake.yml
@@ -7,6 +7,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   make:

--- a/.github/workflows/s390x_linux_cmake.yml
+++ b/.github/workflows/s390x_linux_cmake.yml
@@ -7,6 +7,9 @@ on:
     # min hours day(month) month day(week)
     - cron: '0 0 7,22 * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Building using the github runner environement directly.
   make:

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -2,6 +2,9 @@ name: Zig Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   zig-fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

CI workflows are missing top-level \`permissions\` declarations and reference actions by mutable tags/branch names — both are supply-chain risk vectors.

**Changes:**
- Add \`permissions: read-all\` at the workflow level (least-privilege default for all jobs)
- Pin all third-party action references to full commit SHAs

Mutable action references (\`@v4\`, \`@master\`, etc.) allow a compromised upstream to inject arbitrary code into your CI. Pinning to a commit SHA ensures only the audited revision runs regardless of upstream changes.