### PR TITLE
Update bazel module setup

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "cpu_features",
-    version = "0.11.0",  # CPU_FEATURES_VERSION
+    version = "0.11.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,16 +1,6 @@
-###############################################################################
-# Bazel now uses Bzlmod by default to manage external dependencies.
-# Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel.
-#
-# For more details, please check https://github.com/bazelbuild/bazel/issues/18958
-###############################################################################
-
-CPU_FEATURES_VERSION = "0.11.0"
-
 module(
     name = "cpu_features",
-    repo_name = "com_google_cpufeatures",
-    version = CPU_FEATURES_VERSION,
+    version = "0.11.0",  # CPU_FEATURES_VERSION
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -63,7 +63,7 @@ echo -e "${ACTION}Modifying CMakeLists.txt${NOCOLOR}"
 sed -i "s/CpuFeatures VERSION ${LATEST_VERSION}/CpuFeatures VERSION ${VERSION}/g" CMakeLists.txt
 
 echo -e "${ACTION}Modifying MODULE.bazel${NOCOLOR}"
-sed -i "s/CPU_FEATURES_VERSION = \"${LATEST_VERSION}\"/CPU_FEATURES_VERSION = \"${VERSION}\"/g" MODULE.bazel
+sed -i "s/version = \"${LATEST_VERSION}\",  # CPU_FEATURES_VERSION/version = \"${VERSION}\",  # CPU_FEATURES_VERSION/g" MODULE.bazel
 
 echo -e "${ACTION}Modifying build.zig.zon${NOCOLOR}" 
 sed -i "s/.version = \"${LATEST_VERSION}\"/.version = \"${VERSION}\"/g" build.zig.zon 

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -63,7 +63,7 @@ echo -e "${ACTION}Modifying CMakeLists.txt${NOCOLOR}"
 sed -i "s/CpuFeatures VERSION ${LATEST_VERSION}/CpuFeatures VERSION ${VERSION}/g" CMakeLists.txt
 
 echo -e "${ACTION}Modifying MODULE.bazel${NOCOLOR}"
-sed -i "s/version = \"${LATEST_VERSION}\",  # CPU_FEATURES_VERSION/version = \"${VERSION}\",  # CPU_FEATURES_VERSION/g" MODULE.bazel
+buildozer "set version ${LATEST_VERSION}" //MODULE.bazel:cpu_features
 
 echo -e "${ACTION}Modifying build.zig.zon${NOCOLOR}" 
 sed -i "s/.version = \"${LATEST_VERSION}\"/.version = \"${VERSION}\"/g" build.zig.zon 

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -63,7 +63,7 @@ echo -e "${ACTION}Modifying CMakeLists.txt${NOCOLOR}"
 sed -i "s/CpuFeatures VERSION ${LATEST_VERSION}/CpuFeatures VERSION ${VERSION}/g" CMakeLists.txt
 
 echo -e "${ACTION}Modifying MODULE.bazel${NOCOLOR}"
-buildozer "set version ${LATEST_VERSION}" //MODULE.bazel:cpu_features
+buildozer "set version ${VERSION}" //MODULE.bazel:cpu_features
 
 echo -e "${ACTION}Modifying build.zig.zon${NOCOLOR}" 
 sed -i "s/.version = \"${LATEST_VERSION}\"/.version = \"${VERSION}\"/g" build.zig.zon 


### PR DESCRIPTION
Downstream in the bazel central registry there is some naive parsing
that doesn't work well with constants like this. We can inline this
value instead. I left around CPU_FEATURES_VERSION to make sure the sed
was unambiguous.

This also removes the `repo_name` which was unused
