### PR TITLE
string_view: fix HasWord false negative after a non-boundary partial match

### DIFF
--- a/src/string_view.c
+++ b/src/string_view.c
@@ -162,10 +162,15 @@ bool CpuFeatures_StringView_HasWord(const StringView line,
     if (index_of_word < 0) {
       return false;
     } else {
+      // index_of_word is relative to `remainder`; convert it to an absolute
+      // index into `line` so the boundary checks see the real neighbours.
+      // (On later iterations `remainder` no longer starts at `line`.)
+      const size_t absolute_index =
+          (line.size - remainder.size) + (size_t)index_of_word;
       const StringView before =
-          CpuFeatures_StringView_KeepFront(line, index_of_word);
+          CpuFeatures_StringView_KeepFront(line, absolute_index);
       const StringView after =
-          CpuFeatures_StringView_PopFront(line, index_of_word + word.size);
+          CpuFeatures_StringView_PopFront(line, absolute_index + word.size);
       const bool valid_before =
           before.size == 0 || CpuFeatures_StringView_Back(before) == separator;
       const bool valid_after =

--- a/test/string_view_test.cc
+++ b/test/string_view_test.cc
@@ -182,6 +182,14 @@ TEST(StringViewTest, CpuFeatures_StringView_HasWord) {
       CpuFeatures_StringView_HasWord(str("first middle last"), "mid", ' '));
   EXPECT_FALSE(
       CpuFeatures_StringView_HasWord(str("first middle last"), "las", ' '));
+  // Regression: the searched word appears as a real token, but an earlier
+  // non-boundary partial occurrence forces a second loop iteration. HasWord
+  // used to run the separator checks with a remainder-relative index against
+  // the whole line, producing a false negative on the real token.
+  EXPECT_TRUE(CpuFeatures_StringView_HasWord(str("foox foo"), "foo", ' '));
+  EXPECT_TRUE(CpuFeatures_StringView_HasWord(str("xvme vme"), "vme", ' '));
+  // A repeated prefix that is never its own token must still not match.
+  EXPECT_FALSE(CpuFeatures_StringView_HasWord(str("foofoo bar"), "foo", ' '));
 }
 
 TEST(StringViewTest, CpuFeatures_StringView_GetAttributeKeyValue) {


### PR DESCRIPTION
## Description

`CpuFeatures_StringView_HasWord` detects a separator-delimited word in a line (used to find CPU features in `/proc/cpuinfo` flag lists). It searches for the word in `remainder` — which advances every loop iteration — but runs the separator-boundary checks by slicing `before`/`after` from the original `line` using that **remainder-relative** index:

```c
const int index_of_word = CpuFeatures_StringView_IndexOf(remainder, word);
...
const StringView before = CpuFeatures_StringView_KeepFront(line, index_of_word);
const StringView after  = CpuFeatures_StringView_PopFront(line, index_of_word + word.size);
...
remainder = CpuFeatures_StringView_PopFront(remainder, index_of_word + word.size);
```

On the first iteration `remainder == line`, so the index is correct. But once an earlier, non-boundary partial occurrence advances `remainder`, `index_of_word` is relative to the shorter `remainder` while still being applied to the full `line` — so the boundary checks examine the wrong characters and the function returns a **false negative** for a word that really is present as a token.

Example: `HasWord("foox foo", "foo", ' ')` returns `false` even though `foo` is the second token. This affects any feature whose name first appears as a non-boundary substring of an earlier token and then again as its own token (e.g. MIPS/LoongArch flag lists such as `... mips32r2 mips32 ...` searching for `mips32`).

## Fix

Convert the remainder-relative index to an absolute index into `line` before slicing (`remainder` is always a suffix of `line`, so its offset is `line.size - remainder.size`). This keeps the boundary checks anchored to the full line.

Note: naively switching the slices to `remainder` instead would introduce a *false positive* at remainder-start boundaries — e.g. `HasWord("foofoo bar", "foo", ' ')` would then wrongly match. The absolute-index form avoids that.

## Testing

Extended the existing `StringViewTest.CpuFeatures_StringView_HasWord` test:
- **Before the fix:** `HasWord("foox foo","foo",' ')` and `HasWord("xvme vme","vme",' ')` return `false` → the test FAILS.
- **After the fix:** both return `true`, the no-false-positive guard (`HasWord("foofoo bar","foo",' ')` → `false`) holds, and the full suite is green under ASan/UBSan (`ctest`: 4/4; `string_view_test`: 17/17).
