### PR TITLE
ndk_compat: bound the shift in set_cpu_mask_bit

### DIFF
--- a/ndk_compat/cpu-features.c
+++ b/ndk_compat/cpu-features.c
@@ -27,7 +27,11 @@ static uint32_t g_cpuIdArm;
 #endif
 
 static void set_cpu_mask_bit(uint32_t index, uint32_t* cpu_mask) {
-  *cpu_mask |= 1UL << index;
+  // cpu_mask is a 32-bit mask; a larger index would shift past its width
+  // (shifting by >= the operand width is undefined behavior). The range path
+  // in parse_cpu_mask bounds indices the same way.
+  if (index >= 32) return;
+  *cpu_mask |= (uint32_t)1 << index;
 }
 
 // Examples of valid inputs: "31", "4-31"


### PR DESCRIPTION
## Description

`parse_cpu_mask` parses a CPU-topology mask (e.g. from `/sys/devices/system/cpu/.../topology`). Its single-index branch calls `set_cpu_mask_bit(cpu_index, ...)` with the parsed index directly, and the helper does:

```c
*cpu_mask |= 1UL << index;
```

`cpu_mask` is a `uint32_t` (a 32-CPU mask). An `index >= 32` truncates into the mask, and an `index` >= the width of the shifted type — a lone core index `>= 64` on a many-core machine, or a crafted/foreign topology line — makes `1UL << index` **undefined behavior**. The range branch already guards `if (i < 32)`; the single-index branch has no such bound.

## Fix

Bound the shift inside `set_cpu_mask_bit` (so both callers are covered), matching the existing 32-CPU limit, and shift a `uint32_t` to match the mask type.

## Testing

`ndk_compat` isn't built on this x86 host, but the change is a localized guard consistent with the range path's existing `i < 32` check and the `uint32_t` mask width.
