### PR TITLE
hwcaps: dont return an uninitialized hwcap on elf_aux_info failure

### DIFF
--- a/src/hwcaps_freebsd_or_openbsd.c
+++ b/src/hwcaps_freebsd_or_openbsd.c
@@ -30,7 +30,10 @@ const char* CpuFeatures_GetBasePlatformPointer(void);
 #include <sys/auxv.h>
 
 static unsigned long GetElfHwcapFromElfAuxInfo(int hwcap_type) {
-  unsigned long hwcap;
+  unsigned long hwcap = 0;
+  // elf_aux_info() leaves the output buffer untouched when the requested entry
+  // is absent (e.g. AT_HWCAP2 on some arch/kernel combos), so initializing
+  // hwcap to 0 avoids returning an indeterminate value on failure.
   elf_aux_info(hwcap_type, &hwcap, sizeof(hwcap));
   return hwcap;
 }


### PR DESCRIPTION
## Description

On FreeBSD/OpenBSD, `GetElfHwcapFromElfAuxInfo` reads the ELF hwcaps via `elf_aux_info`:

```c
static unsigned long GetElfHwcapFromElfAuxInfo(int hwcap_type) {
  unsigned long hwcap;
  elf_aux_info(hwcap_type, &hwcap, sizeof(hwcap));
  return hwcap;
}
```

`hwcap` is uninitialized and the `elf_aux_info` return value is ignored. `elf_aux_info` only writes `*buf` on success; when the requested entry is absent it returns non-zero and leaves the buffer **untouched**. `CpuFeatures_GetHardwareCapabilities` requests `AT_HWCAP2` unconditionally, and `AT_HWCAP2` is genuinely absent on some arch/kernel combinations — so on those, this returns an **indeterminate stack value**, which is then bit-tested for CPU features → non-deterministic false detection.

## Fix

Initialize `hwcap = 0` and return 0 when `elf_aux_info` fails, mirroring the Linux `getauxval` path (which returns 0 when the entry is unavailable).

## Testing

FreeBSD/OpenBSD-only path, so not exercised on this Linux host; the fix is a straightforward initialize + return-check (the uninitialized read is clear from the source).
