### PR TITLE
Move googletest to `dev_dependency = True`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,5 +5,6 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "rules_cc", version = "0.2.17")
-bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 bazel_dep(name = "platforms", version = "1.0.0")
+
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)


### PR DESCRIPTION
`googletest` is not needed by core `cpu_features` libraries and brings in additional dependencies. This change moves it to `dev_dependency = True` to avoid this impact on consumers.